### PR TITLE
do not require domain param in unbound forwarding module

### DIFF
--- a/docs/source/modules/unbound_forwarding.rst
+++ b/docs/source/modules/unbound_forwarding.rst
@@ -22,8 +22,8 @@ Definition
     :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
     :widths: 15 10 10 10 10 45
 
-    "domain","string","false","\-","dom, d","Domain to forward queries of"
-    "target","string","true","\-","server, srv, tgt","DNS target server"
+    "domain","string","false","\-","dom, d","Domain of the host. All queries for this domain will be forwarded to the nameserver specified. Leave empty to catch all queries and forward them to the nameserver"
+    "target","string","true","\-","server, srv, tgt","Server to forward the dns queries to"
     "port","string","false","53","p","DNS port of the target server"
     "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
 

--- a/docs/source/modules/unbound_forwarding.rst
+++ b/docs/source/modules/unbound_forwarding.rst
@@ -22,7 +22,7 @@ Definition
     :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
     :widths: 15 10 10 10 10 45
 
-    "domain","string","true","\-","dom, d","Domain to forward queries of"
+    "domain","string","false","\-","dom, d","Domain to forward queries of"
     "target","string","true","\-","server, srv, tgt","DNS target server"
     "port","string","false","53","p","DNS port of the target server"
     "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst

--- a/plugins/module_utils/main/unbound_forward.py
+++ b/plugins/module_utils/main/unbound_forward.py
@@ -44,7 +44,9 @@ class Forward(BaseModule):
         #   https://github.com/opnsense/core/commit/6832fd75a0b41e376e80f287f8ad3cfe599ea3d1
 
     def check(self) -> None:
-        validate_domain(module=self.m, domain=self.p['domain'])
+        if self.p['domain']:
+          validate_domain(module=self.m, domain=self.p['domain'])
+
         validate_port(module=self.m, port=self.p['port'])
 
         self.b.find(match_fields=['domain', 'target'])

--- a/plugins/module_utils/main/unbound_forward.py
+++ b/plugins/module_utils/main/unbound_forward.py
@@ -5,7 +5,7 @@ from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api impor
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.unbound import \
     validate_domain
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.main import \
-    validate_port, is_true
+    validate_port, is_true, is_unset
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
 
 
@@ -44,7 +44,7 @@ class Forward(BaseModule):
         #   https://github.com/opnsense/core/commit/6832fd75a0b41e376e80f287f8ad3cfe599ea3d1
 
     def check(self) -> None:
-        if self.p['domain']:
+        if not is_unset(self.p['domain']):
           validate_domain(module=self.m, domain=self.p['domain'])
 
         validate_port(module=self.m, port=self.p['port'])

--- a/plugins/modules/unbound_forward.py
+++ b/plugins/modules/unbound_forward.py
@@ -28,7 +28,7 @@ EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/unbound_forwarding
 
 def run_module():
     module_args = dict(
-        domain=dict(type='str', required=True, aliases=['dom', 'd']),
+        domain=dict(type='str', required=False, default='', aliases=['dom', 'd']),
         target=dict(
             type='str', required=True, aliases=['tgt', 'server', 'srv'],
             description='Server to forward the dns queries to'

--- a/plugins/modules/unbound_forward.py
+++ b/plugins/modules/unbound_forward.py
@@ -28,7 +28,11 @@ EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/unbound_forwarding
 
 def run_module():
     module_args = dict(
-        domain=dict(type='str', required=False, default='', aliases=['dom', 'd']),
+        domain=dict(
+            type='str', required=False, default='', aliases=['dom', 'd'],
+            description='Domain of the host. All queries for this domain will be forwarded to the nameserver '
+                        'specified. Leave empty to catch all queries and forward them to the nameserver'
+        ),
         target=dict(
             type='str', required=True, aliases=['tgt', 'server', 'srv'],
             description='Server to forward the dns queries to'
@@ -37,7 +41,7 @@ def run_module():
             type='int', required=False, default=53, aliases=['p'],
             description='DNS port of the target server'
         ),
-        type=dict(type='str', required=False, choises=['forward'], default='forward'),
+        type=dict(type='str', required=False, choices=['forward'], default='forward'),
         **RELOAD_MOD_ARG,
         **STATE_MOD_ARG,
         **OPN_MOD_ARGS,

--- a/tests/cleanup.yml
+++ b/tests/cleanup.yml
@@ -86,6 +86,7 @@
       loop:
         - {d: 'fwd.opnsense.test.ansibleguy.net', t: '1.1.1.1'}
         - {d: 'fwd.opnsense.test.ansibleguy.net', t: '1.1.1.2'}
+        - {d: '', t: '1.1.1.3'}
 
     - name: Cleanup DNS host-override aliases
       ansibleguy.opnsense.unbound_host_alias:

--- a/tests/unbound_forward.yml
+++ b/tests/unbound_forward.yml
@@ -56,14 +56,14 @@
         opn5.failed or
         not opn5.changed
 
-    - name: Adding 3
+    - name: Adding 3 - catch-all
       ansibleguy.opnsense.unbound_forward:
         target: '1.1.1.3'
         reload: false  # speed
-      register: opn10
+      register: opn11
       failed_when: >
-        opn10.failed or
-        not opn10.changed
+        opn11.failed or
+        not opn11.changed
 
     - name: Disabling 2
       ansibleguy.opnsense.unbound_forward:
@@ -116,7 +116,7 @@
       register: opn3
       failed_when: >
         'data' not in opn3 or
-        opn3.data | length != 1
+        opn3.data | length != 2
       when: not ansible_check_mode
 
     - name: Cleanup
@@ -127,6 +127,7 @@
       loop:
         - {d: 'fwd.opnsense.test.ansibleguy.net', t: '1.1.1.1'}
         - {d: 'fwd.opnsense.test.ansibleguy.net', t: '1.1.1.2'}
+        - {d: '', t: '1.1.1.3'}
       when: not ansible_check_mode
 
     - name: Listing

--- a/tests/unbound_forward.yml
+++ b/tests/unbound_forward.yml
@@ -56,6 +56,15 @@
         opn5.failed or
         not opn5.changed
 
+    - name: Adding 3
+      ansibleguy.opnsense.unbound_forward:
+        target: '1.1.1.3'
+        reload: false  # speed
+      register: opn10
+      failed_when: >
+        opn10.failed or
+        not opn10.changed
+
     - name: Disabling 2
       ansibleguy.opnsense.unbound_forward:
         domain: 'fwd.opnsense.test.ansibleguy.net'


### PR DESCRIPTION
This PR changes the `domain` parameter for the `unbound_forwarding` module to be **not required** anymore. This enables the forwarding of all DNS requests.  