### PR TITLE
[bind_record_multi] Records lost in validation

### DIFF
--- a/plugins/module_utils/main/bind_record_multi.py
+++ b/plugins/module_utils/main/bind_record_multi.py
@@ -61,19 +61,22 @@ def process(m: AnsibleModule, p: dict, r: dict) -> None:
 
             record = convert_aliases(cnf=record, aliases=RECORD_MOD_ARG_ALIASES)
 
-            try:
-                record_key = f"{record['name']}.{domain}"
-
-            except KeyError:
-                # placeholder => will fail verification anyway
-                record_key = f'NONE.{domain}'
-
             real_cnf = {
                 **RECORD_DEFAULTS,
                 **defaults,
                 **record,
                 **overrides,
             }
+
+            try:
+                record_keys = list(map(real_cnf.get, real_cnf['match_fields']))
+                if len(record_keys) == 0:
+                    raise KeyError
+                record_key = '|'.join(record_keys)
+
+            except KeyError:
+                # placeholder => will fail verification anyway
+                record_key = f'NONE.{domain}'
 
             if real_cnf['debug']:
                 m.warn(f"Validating record: '{record_key} => {real_cnf}'")

--- a/tests/bind_record_multi.yml
+++ b/tests/bind_record_multi.yml
@@ -116,12 +116,28 @@
         opn3.changed
       when: not ansible_check_mode
 
+    - name: Adding 2
+      ansibleguy.opnsense.bind_record_multi:
+        records:
+          'test4.ansibleguy':
+            - name: 'test5'
+              type: 'A'
+              value: '192.168.5.1'
+            - name: 'test5'
+              type: 'AAAA'
+              value: '::2'
+      register: opn4
+      failed_when: >
+        opn4.failed or
+        not opn4.changed
+      when: not ansible_check_mode
+
     - name: Listing
       ansibleguy.opnsense.list:
       register: opn8
       failed_when: >
         'data' not in opn8 or
-        opn8.data | length != 3
+        opn8.data | length != 6
       when: not ansible_check_mode
 
     - name: Cleanup
@@ -135,6 +151,12 @@
             - 'test3'
             - name: 'test4'
               type: 'CNAME'
+            - name: 'test5'
+              type: 'A'
+              value: '192.168.1.2'
+            - name: 'test5'
+              type: 'AAAA'
+              value: '::2'
         state: 'absent'
       when: not ansible_check_mode
 

--- a/tests/cleanup.yml
+++ b/tests/cleanup.yml
@@ -370,11 +370,15 @@
             - name: 'test1'
               type: 'TXT'
             - 'test2'
-            - name: 'test2'
-              type: 'TXT'
             - 'test3'
             - name: 'test4'
               type: 'CNAME'
+            - name: 'test5'
+              type: 'A'
+              value: '192.168.1.2'
+            - name: 'test5'
+              type: 'AAAA'
+              value: '::2'
         state: 'absent'
       ignore_errors: true  # domain does not exist
 


### PR DESCRIPTION
It is currently not possible to use ansibleguy.opnsense.bind_record_multi to add DNS records with the same name but a different type.
The result of the following action is that only the last record is added.

    - name: Test
      ansibleguy.opnsense.bind_record_multi:
        records:
          'test4.ansibleguy':
            - name: 'test5'
              type: 'A'
              value: '192.168.1.2'
            - name: 'test5'
              type: 'AAAA'
              value: '::2'

The debug logging shows the problem.
Of the two records that are validated only the last is processed.

[WARNING]: Validating record: 'test5.test4.ansibleguy => {'type': 'A', 'value':'192.168.1.2', 'round_robin': False, 'state': 'present', 'enabled': True,'name': 'test5', 'match_fields': ['domain', 'name', 'type'], 'debug': True,'firewall': '192.168.60.101', 'domain': 'test4.ansibleguy'}'
[WARNING]: Validating record: 'test5.test4.ansibleguy => {'type': 'AAAA','value': '::2', 'round_robin': False, 'state': 'present', 'enabled': True,'name': 'test5', 'match_fields': ['domain', 'name', 'type'], 'debug': True,'firewall': '192.168.60.101', 'domain': 'test4.ansibleguy'}'
[WARNING]: Processing record: 'test5.test4.ansibleguy => {'type': 'AAAA','value': '::2', 'round_robin': False, 'state': 'present', 'enabled': True,'name': 'test5', 'match_fields': ['domain', 'name', 'type'], 'debug': True,'firewall': '192.168.60.101', 'domain': 'test4.ansibleguy'}'

In bind_record_multi.py the entries are validated and, if valid, stored in the 'valid_records' dictionary that uses only the 'name' of the entry as the key.
This code does not take the 'match_fields' property into account, resulting in above mentioned problem.

This fix ensures that all the values of the properties specified in 'match_fields' are used as the key for the 'valid_records' dictionary.

