### PR TITLE
Adding general option for API retries

### DIFF
--- a/docs/source/modules/1_basic.rst
+++ b/docs/source/modules/1_basic.rst
@@ -18,6 +18,7 @@ All modules
     api_key, string, "false, true if 'api_credential_file' is not used", \- , "API key used to authenticate, alternative to 'api_credential_file'"
     api_secret, string, "false, true if 'api_credential_file' is not used", \- , "API secret used to authenticate, alternative to 'api_credential_file'. Is set as 'no_log' parameter."
     api_credential_file, path, "false, true if 'api_key' and 'api_secret' are not used", \- , "Path to the api-credential file as downloaded through the web-interface. Alternative to 'api_key' and 'api_secret'."
+    api_retries, int, false, 3, "Number of retries on API requests, when there is a connection error or timeout."
     ssl_verify, bool, false, true, "If the certificate of the target firewall should be validated. RECOMMENDED FOR PRODUCTION USAGE!"
     ssl_ca_file, path, false, \- , "If you use an internal certificate-authority to create the certificate of the target firewall, provide the path to its public key for validation."
     debug, boolean, false, false, "Used to en-/disable the debug mode. All API requests and responses will be shown as Ansible warnings at runtime. Will be hidden if the tasks 'no_log' parameter is set to 'true'."

--- a/docs/source/modules/1_basic.rst
+++ b/docs/source/modules/1_basic.rst
@@ -14,16 +14,16 @@ All modules
     :widths: 15 10 10 10 55
 
     firewall, string, true, \- , "IP-Address or DNS hostname of the target firewall. Must be included as 'common name' in the firewalls web-certificate to use 'ssl_verify=true'"
-    api_port, int, false, 443, "Port the target firewall uses for its web-interface"
+    api_port, integer, false, 443, "Port the target firewall uses for its web-interface"
     api_key, string, "false, true if 'api_credential_file' is not used", \- , "API key used to authenticate, alternative to 'api_credential_file'"
     api_secret, string, "false, true if 'api_credential_file' is not used", \- , "API secret used to authenticate, alternative to 'api_credential_file'. Is set as 'no_log' parameter."
     api_credential_file, path, "false, true if 'api_key' and 'api_secret' are not used", \- , "Path to the api-credential file as downloaded through the web-interface. Alternative to 'api_key' and 'api_secret'."
-    api_retries, int, false, 3, "Number of retries on API requests, when there is a connection error or timeout."
     ssl_verify, bool, false, true, "If the certificate of the target firewall should be validated. RECOMMENDED FOR PRODUCTION USAGE!"
     ssl_ca_file, path, false, \- , "If you use an internal certificate-authority to create the certificate of the target firewall, provide the path to its public key for validation."
     debug, boolean, false, false, "Used to en-/disable the debug mode. All API requests and responses will be shown as Ansible warnings at runtime. Will be hidden if the tasks 'no_log' parameter is set to 'true'."
     profiling, boolean, false, false, "Used to en-/disable the profiling mode. Time consumption of the module will be logged to '/tmp/ansibleguy.opnsense'."
-    timeout, float, false, \- , "Manually override the modules default timeout"
+    timeout, float, false, \- , "Manually override the modules default API-request timeout. Mind that every request retry might consume this amount of time!"
+    retries, integer, false, 1, "Number of retries on API requests, in case there is a connection error or timeout."
 
 Modules managing multiple entries
 *********************************

--- a/docs/source/modules/1_basic.rst
+++ b/docs/source/modules/1_basic.rst
@@ -10,27 +10,27 @@ All modules
 ***********
 
 ..  csv-table:: Definition
-    :header: "Parameter", "Type", "Required", "Default", "Comment"
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
     :widths: 15 10 10 10 55
 
-    firewall, string, true, \- , "IP-Address or DNS hostname of the target firewall. Must be included as 'common name' in the firewalls web-certificate to use 'ssl_verify=true'"
-    api_port, integer, false, 443, "Port the target firewall uses for its web-interface"
-    api_key, string, "false, true if 'api_credential_file' is not used", \- , "API key used to authenticate, alternative to 'api_credential_file'"
-    api_secret, string, "false, true if 'api_credential_file' is not used", \- , "API secret used to authenticate, alternative to 'api_credential_file'. Is set as 'no_log' parameter."
-    api_credential_file, path, "false, true if 'api_key' and 'api_secret' are not used", \- , "Path to the api-credential file as downloaded through the web-interface. Alternative to 'api_key' and 'api_secret'."
-    ssl_verify, bool, false, true, "If the certificate of the target firewall should be validated. RECOMMENDED FOR PRODUCTION USAGE!"
-    ssl_ca_file, path, false, \- , "If you use an internal certificate-authority to create the certificate of the target firewall, provide the path to its public key for validation."
-    debug, boolean, false, false, "Used to en-/disable the debug mode. All API requests and responses will be shown as Ansible warnings at runtime. Will be hidden if the tasks 'no_log' parameter is set to 'true'."
-    profiling, boolean, false, false, "Used to en-/disable the profiling mode. Time consumption of the module will be logged to '/tmp/ansibleguy.opnsense'."
-    timeout, float, false, \- , "Manually override the modules default API-request timeout. Mind that every request retry might consume this amount of time!"
-    retries, integer, false, 1, "Number of retries on API requests, in case there is a connection error or timeout."
+    firewall, string, true, "\-", "\-", "IP-Address or DNS hostname of the target firewall. Must be included as 'common name' or 'subject alternative name' in the firewalls web-certificate to use 'ssl_verify=true'"
+    api_port, integer, false, 443, "\-", "Port the target firewall uses for its web-interface"
+    api_key, string, "false, true if 'api_credential_file' is not used", "\-", "\-", "API key used to authenticate, alternative to 'api_credential_file'"
+    api_secret, string, "false, true if 'api_credential_file' is not used", "\-", "\-", "API secret used to authenticate, alternative to 'api_credential_file'. Is set as 'no_log' parameter"
+    api_credential_file, path, "false, true if 'api_key' and 'api_secret' are not used", "\-", "\-", "Path to the api-credential file as downloaded through the web-interface. Alternative to 'api_key' and 'api_secret'"
+    ssl_verify, bool, false, true, "\-", "If the certificate of the target firewall should be validated. RECOMMENDED FOR PRODUCTION USAGE!"
+    ssl_ca_file, path, false, "\-", "\-", "If you use an internal certificate-authority to create the certificate of the target firewall, provide the path to its public key for validation"
+    debug, boolean, false, false, "\-", "Used to en-/disable the debug mode. All API requests and responses will be shown as Ansible warnings at runtime. Will be hidden if the tasks 'no_log' parameter is set to 'true'"
+    profiling, boolean, false, false, "\-", "Used to en-/disable the profiling mode. Time consumption of the module will be logged to '/tmp/ansibleguy.opnsense'"
+    api_timeout, float, false, "\-", "timeout", "Manually override the modules default API-request timeout"
+    api_retries, integer, false, "0", "connect_retries", "Number of retries on API requests, in case there is an error when ESTABLISHING the connection. This does not handle errors returned by the OPNSense system"
 
 Modules managing multiple entries
 *********************************
 
 ..  csv-table:: Definition
-    :header: "Parameter", "Type", "Required", "Default", "Comment"
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
     :widths: 15 10 10 10 55
 
-    "enabled","boolean","false","true","En- or disable the entry"
-    "state","string","false","present","One of 'present', 'absent'. Add or remove the entry"
+    "enabled","boolean","false","true","\-","En- or disable the entry"
+    "state","string","false","present","\-","One of 'present', 'absent'. Add or remove the entry"

--- a/plugins/module_utils/base/api.py
+++ b/plugins/module_utils/base/api.py
@@ -24,8 +24,8 @@ class Session:
         check_host(module=self.m)
         check_or_load_credentials(module=self.m)
 
-        if 'timeout' in self.m.params and self.m.params['timeout'] is not None:
-            timeout = self.m.params['timeout']
+        if 'api_timeout' in self.m.params and self.m.params['api_timeout'] is not None:
+            timeout = self.m.params['api_timeout']
 
         setdefaulttimeout(timeout)
 
@@ -35,7 +35,7 @@ class Session:
             timeout=httpx.Timeout(timeout=timeout),
             transport=httpx.HTTPTransport(
                 verify=ssl_verification(module=self.m),
-                retries=self.m.params['retries'],
+                retries=self.m.params['api_retries'],
             ),
         )
 

--- a/plugins/module_utils/defaults/main.py
+++ b/plugins/module_utils/defaults/main.py
@@ -4,6 +4,7 @@ OPN_MOD_ARGS = dict(
     api_key=dict(type='str', required=False, no_log=True),
     api_secret=dict(type='str', required=False, no_log=True),
     api_credential_file=dict(type='path', required=False),
+    api_retries=dict(type='int', required=False, default=3),
     ssl_verify=dict(type='bool', required=False, default=True),
     ssl_ca_file=dict(type='path', required=False),
     debug=dict(type='bool', required=False, default=False),

--- a/plugins/module_utils/defaults/main.py
+++ b/plugins/module_utils/defaults/main.py
@@ -1,16 +1,58 @@
 OPN_MOD_ARGS = dict(
-    firewall=dict(type='str', required=True),
-    api_port=dict(type=int, required=False, default=443),
-    api_key=dict(type='str', required=False, no_log=True),
-    api_secret=dict(type='str', required=False, no_log=True),
-    api_credential_file=dict(type='path', required=False),
-    ssl_verify=dict(type='bool', required=False, default=True),
-    ssl_ca_file=dict(type='path', required=False),
-    debug=dict(type='bool', required=False, default=False),
-    profiling=dict(type='bool', required=False, default=False),
-    timeout=dict(type='float', required=False),
-    retries=dict(type='int', required=False, default=1),
+    firewall=dict(
+        type='str', required=True,
+        description="IP-Address or DNS hostname of the target firewall. "
+                    "Must be included as 'common name' or 'subject alternative name' in the firewalls web-certificate "
+                    "to use 'ssl_verify=true'"
+    ),
+    api_port=dict(
+        type=int, required=False, default=443,
+        description='Port the target firewall uses for its web-interface'
+    ),
+    api_key=dict(
+        type='str', required=False, no_log=True,
+        description="API key used to authenticate, alternative to 'api_credential_file'"
+    ),
+    api_secret=dict(
+        type='str', required=False, no_log=True,
+        description="API secret used to authenticate, alternative to 'api_credential_file'. "
+                    "Is set as 'no_log' parameter"
+    ),
+    api_credential_file=dict(
+        type='path', required=False,
+        description="Path to the api-credential file as downloaded through the web-interface. "
+                    "Alternative to 'api_key' and 'api_secret'"
+    ),
+    ssl_verify=dict(
+        type='bool', required=False, default=True,
+        description='If the certificate of the target firewall should be validated. RECOMMENDED FOR PRODUCTION USAGE!'
+    ),
+    ssl_ca_file=dict(
+        type='path', required=False,
+        description='If you use an internal certificate-authority to create the certificate of the target firewall, '
+                    'provide the path to its public key for validation'
+    ),
+    debug=dict(
+        type='bool', required=False, default=False,
+        description="Used to en-/disable the debug mode. All API requests and responses will be shown "
+                    "as Ansible warnings at runtime. Will be hidden if the tasks 'no_log' parameter is set to 'true'"
+    ),
+    profiling=dict(
+        type='bool', required=False, default=False,
+        description="Used to en-/disable the profiling mode. "
+                    "Time consumption of the module will be logged to '/tmp/ansibleguy.opnsense'"
+    ),
+    api_timeout=dict(
+        type='float', required=False, aliases=['timeout'],
+        description='Manually override the modules default API-request timeout'
+    ),
+    api_retries=dict(
+        type='int', required=False, default=0, aliases=['connect_retries'],
+        description='Number of retries on API requests, in case there is an error when establishing the connection. '
+                    'This does not handle errors returned by the OPNSense system'
+    ),
 )
+
 BUILTIN_ALIASES = [
     'bogons', 'bogonsv6', 'sshlockout', 'virusprot',
 ]

--- a/plugins/module_utils/defaults/main.py
+++ b/plugins/module_utils/defaults/main.py
@@ -10,6 +10,7 @@ OPN_MOD_ARGS = dict(
     debug=dict(type='bool', required=False, default=False),
     profiling=dict(type='bool', required=False, default=False),
     timeout=dict(type='float', required=False),
+    retries=dict(type='int', required=False, default=1),
 )
 BUILTIN_ALIASES = [
     'bogons', 'bogonsv6', 'sshlockout', 'virusprot',

--- a/plugins/module_utils/defaults/main.py
+++ b/plugins/module_utils/defaults/main.py
@@ -4,7 +4,6 @@ OPN_MOD_ARGS = dict(
     api_key=dict(type='str', required=False, no_log=True),
     api_secret=dict(type='str', required=False, no_log=True),
     api_credential_file=dict(type='path', required=False),
-    api_retries=dict(type='int', required=False, default=3),
     ssl_verify=dict(type='bool', required=False, default=True),
     ssl_ca_file=dict(type='path', required=False),
     debug=dict(type='bool', required=False, default=False),

--- a/plugins/module_utils/helper/api.py
+++ b/plugins/module_utils/helper/api.py
@@ -196,16 +196,3 @@ def api_pretty_exception(method: str, url: str, error) -> ConnectionError:
         msg = f"Got timeout calling '{call}'!"
 
     return ConnectionError(msg)
-
-
-def timeout_override(module: AnsibleModule, timeout: float) -> float:
-    if 'timeout' in module.params and module.params['timeout'] is not None:
-        timeout = module.params['timeout']
-
-    return timeout
-
-def get_api_retries(module: AnsibleModule) -> int:
-    if not module.params['api_retries']:
-        return 3
-
-    return module.params['api_retries']

--- a/plugins/module_utils/helper/api.py
+++ b/plugins/module_utils/helper/api.py
@@ -203,3 +203,9 @@ def timeout_override(module: AnsibleModule, timeout: float) -> float:
         timeout = module.params['timeout']
 
     return timeout
+
+def get_api_retries(module: AnsibleModule) -> int:
+    if not module.params['api_retries']:
+        return 3
+
+    return module.params['api_retries']


### PR DESCRIPTION
The OPNsense API can be a little bit annoying from time to time. I regularly experience connect errors, either `httpx.ConnectError` or `httpx.ConnectTimeout` to the OPNsense API, which makes the playbook stop with an exception (example below)


Solutions
* use [ansible retry](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#retrying-a-task-until-a-condition-is-met) on every task calling the API (which is annoying on the user side of this collection).
* or implement a retry mechanism on those connect errors, which httpx can do with a custom transport (as the pull request does). 
  See https://www.python-httpx.org/advanced/#custom-transports
  > Connection retries are also available via this interface. Requests will be retried the given number of times in case an httpx.ConnectError or an httpx.ConnectTimeout occurs, allowing smoother operation under flaky networks. 


Discussion points:
* I choose a default for `api_retries` of `3`, which can be discussed.
* I didn't really find a way to write a test. Do you have any ideas on that?
* Am I missing something?

Example of the error:
```
TASK [opnsense-wireguard-network : Adding firewall rules for WireGuard network] ****************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ConnectionError: Unable to connect 'GET => https://192.168.0.1/api/firewall/filter/get'!
failed: [192.168.0.1] (item={'description': 'wan_wireguard_netcup_ipv4', 'interface': 'wan', 'ip_protocol': 'inet', 'destination_net': 'wanip', 'destination_port': 51111, 'protocol': 'UDP'}) => changed=false 
  ansible_loop_var: rule
  module_stderr: |-
    Traceback (most recent call last):
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_exceptions.py", line 10, in map_exceptions
        yield
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_backends/sync.py", line 168, in start_tls
        raise exc
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_backends/sync.py", line 163, in start_tls
        sock = ssl_context.wrap_socket(
      File "/usr/lib/python3.10/ssl.py", line 513, in wrap_socket
        return self.sslsocket_class._create(
      File "/usr/lib/python3.10/ssl.py", line 1100, in _create
        self.do_handshake()
      File "/usr/lib/python3.10/ssl.py", line 1371, in do_handshake
        self._sslobj.do_handshake()
    ConnectionResetError: [Errno 104] Connection reset by peer
  
    The above exception was the direct cause of the following exception:
  
    Traceback (most recent call last):
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_transports/default.py", line 66, in map_httpcore_exceptions
        yield
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_transports/default.py", line 228, in handle_request
        resp = self._pool.handle_request(req)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_sync/connection_pool.py", line 268, in handle_request
        raise exc
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_sync/connection_pool.py", line 251, in handle_request
        response = connection.handle_request(request)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_sync/connection.py", line 99, in handle_request
        raise exc
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_sync/connection.py", line 76, in handle_request
        stream = self._connect(request)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_sync/connection.py", line 156, in _connect
        stream = stream.start_tls(**kwargs)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_backends/sync.py", line 152, in start_tls
        with map_exceptions(exc_map):
      File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
        self.gen.throw(typ, value, traceback)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
        raise to_exc(exc) from exc
    httpcore.ConnectError: [Errno 104] Connection reset by peer
  
    The above exception was the direct cause of the following exception:
  
    Traceback (most recent call last):
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/base/api.py", line 50, in get
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_client.py", line 1041, in get
        return self.request(
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_client.py", line 814, in request
        return self.send(request, auth=auth, follow_redirects=follow_redirects)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_client.py", line 901, in send
        response = self._send_handling_auth(
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_client.py", line 929, in _send_handling_auth
        response = self._send_handling_redirects(
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_client.py", line 966, in _send_handling_redirects
        response = self._send_single_request(request)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_client.py", line 1002, in _send_single_request
        response = transport.handle_request(request)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_transports/default.py", line 227, in handle_request
        with map_httpcore_exceptions():
      File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
        self.gen.throw(typ, value, traceback)
      File "/home/ansible/.local/lib/python3.10/site-packages/httpx/_transports/default.py", line 83, in map_httpcore_exceptions
        raise mapped_exc(message) from exc
    httpx.ConnectError: [Errno 104] Connection reset by peer
  
    During handling of the above exception, another exception occurred:
  
    Traceback (most recent call last):
      File "/home/ansible/.ansible/tmp/ansible-tmp-1703712110.4833777-35213-213337067714811/AnsiballZ_rule.py", line 107, in <module>
        _ansiballz_main()
      File "/home/ansible/.ansible/tmp/ansible-tmp-1703712110.4833777-35213-213337067714811/AnsiballZ_rule.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/ansible/.ansible/tmp/ansible-tmp-1703712110.4833777-35213-213337067714811/AnsiballZ_rule.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible_collections.ansibleguy.opnsense.plugins.modules.rule', init_globals=dict(_module_fqn='ansible_collections.ansibleguy.opnsense.plugins.modules.rule', _modlib_path=modlib_path),
      File "/usr/lib/python3.10/runpy.py", line 224, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/rule.py", line 68, in <module>
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/rule.py", line 64, in main
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/rule.py", line 56, in run_module
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/rule.py", line 46, in process
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/main/rule.py", line 89, in check
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/base/base.py", line 124, in find
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/base/base.py", line 581, in _call_search
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/base/cls.py", line 33, in _search_call
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/base/base.py", line 74, in search
      File "/tmp/ansible_ansibleguy.opnsense.rule_payload_e06dgi7i/ansible_ansibleguy.opnsense.rule_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/base/api.py", line 54, in get
    ConnectionError: Unable to connect 'GET => https://192.168.0.1/api/firewall/filter/get'!
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
  rule:
    description: wan_wireguard_netcup_ipv4
    destination_net: wanip
    destination_port: 51111
    interface: wan
    ip_protocol: inet
    protocol: UDP
```