### PR TITLE
Fix unbound_dot: allow requests without domain parameter set

### DIFF
--- a/plugins/module_utils/main/unbound_dot.py
+++ b/plugins/module_utils/main/unbound_dot.py
@@ -52,10 +52,8 @@ class DnsOverTls(BaseModule):
             )
 
         if is_unset(self.p['domain']):
-            if not is_unset(self.p['verify']):
-                self.b.find(match_fields=['target', 'verify'])
-            else:
-                self.b.find(match_fields=['target'])
+            self.b.find(match_fields=['target'])
+
         else:
             self.b.find(match_fields=['domain', 'target'])
 

--- a/plugins/module_utils/main/unbound_dot.py
+++ b/plugins/module_utils/main/unbound_dot.py
@@ -39,7 +39,8 @@ class DnsOverTls(BaseModule):
         self.dot = {}
 
     def check(self) -> None:
-        validate_domain(module=self.m, domain=self.p['domain'])
+        if not is_unset(self.p['domain']):
+            validate_domain(module=self.m, domain=self.p['domain'])
         validate_port(module=self.m, port=self.p['port'])
 
         if not is_unset(self.p['verify']) and \
@@ -50,7 +51,13 @@ class DnsOverTls(BaseModule):
                 f"nor a valid hostname!"
             )
 
-        self.b.find(match_fields=['domain', 'target'])
+        if is_unset(self.p['domain']):
+            if not is_unset(self.p['verify']):
+                self.b.find(match_fields=['target', 'verify'])
+            else:
+                self.b.find(match_fields=['target'])
+        else:
+            self.b.find(match_fields=['domain', 'target'])
 
         if self.p['state'] == 'present':
             self.r['diff']['after'] = self.b.build_diff(data=self.p)

--- a/tests/cleanup.yml
+++ b/tests/cleanup.yml
@@ -64,13 +64,14 @@
 
     - name: Cleanup Unbound DNS-over-TLS
       ansibleguy.opnsense.unbound_dot:
-        domain: "{{ item.d }}"
-        target: "{{ item.t }}"
+        target: "{{ item }}"
         state: 'absent'
         reload: false  # speed
       loop:
-        - {d: 'dot.opnsense.test.ansibleguy.net', t: '1.1.1.1'}
-        - {d: 'dot.opnsense.test.ansibleguy.net', t: '1.1.1.2'}
+        - '1.1.1.1'
+        - '1.1.1.2'
+        - '1.1.1.3'
+        - '1.1.1.4'
 
     - name: Cleanup Unbound DNS-Forwarding's
       ansibleguy.opnsense.unbound_forward:

--- a/tests/unbound_dot.yml
+++ b/tests/unbound_dot.yml
@@ -127,6 +127,40 @@
         opn3.data | length != 1
       when: not ansible_check_mode
 
+    - name: Adding 3 without domain
+      ansibleguy.opnsense.unbound_dot:
+        target: '1.1.1.3'
+        verify: 'dot.opnsense.test.ansibleguy.net'
+        reload: false  # speed
+      register: opn6
+      failed_when: >
+        opn6.failed or
+        not opn6.changed
+
+    - name: Removing 3
+      ansibleguy.opnsense.unbound_dot:
+        target: '1.1.1.3'
+        verify: 'dot.opnsense.test.ansibleguy.net'
+        state: 'absent'
+        reload: false
+      when: not ansible_check_mode
+
+    - name: Adding 4 without domain or verify
+      ansibleguy.opnsense.unbound_dot:
+        target: '1.1.1.4'
+        reload: false  # speed
+      register: opn7
+      failed_when: >
+        opn7.failed or
+        not opn7.changed
+
+    - name: Removing 4
+      ansibleguy.opnsense.unbound_dot:
+        target: '1.1.1.4'
+        state: 'absent'
+        reload: false
+      when: not ansible_check_mode
+
     - name: Cleanup
       ansibleguy.opnsense.unbound_dot:
         domain: "{{ item.d }}"

--- a/tests/unbound_dot.yml
+++ b/tests/unbound_dot.yml
@@ -137,6 +137,17 @@
         opn6.failed or
         not opn6.changed
 
+    - name: Changing 3 port
+      ansibleguy.opnsense.unbound_dot:
+        target: '1.1.1.3'
+        verify: 'dot.opnsense.test.ansibleguy.net'
+        port: 853
+        reload: false  # speed
+      register: opn6
+      failed_when: >
+        opn6.failed or
+        not opn6.changed
+
     - name: Removing 3
       ansibleguy.opnsense.unbound_dot:
         target: '1.1.1.3'
@@ -154,22 +165,16 @@
         opn7.failed or
         not opn7.changed
 
-    - name: Removing 4
-      ansibleguy.opnsense.unbound_dot:
-        target: '1.1.1.4'
-        state: 'absent'
-        reload: false
-      when: not ansible_check_mode
-
     - name: Cleanup
       ansibleguy.opnsense.unbound_dot:
-        domain: "{{ item.d }}"
-        target: "{{ item.t }}"
+        target: "{{ item }}"
         state: 'absent'
         reload: false
       loop:
-        - {d: 'dot.opnsense.test.ansibleguy.net', t: '1.1.1.1'}
-        - {d: 'dot.opnsense.test.ansibleguy.net', t: '1.1.1.2'}
+        - '1.1.1.1'
+        - '1.1.1.2'
+        - '1.1.1.3'
+        - '1.1.1.4'
       when: not ansible_check_mode
 
     - name: Listing dots


### PR DESCRIPTION
# Description
When creating a DNS over TLS rule in Opnsense, specifying a `target` attribute is required. One may also define one of the following optional parameters: `domain`, `port` or `validate` (and `reload`).

# Expected Behavior
According to the [docs](https://opnsense.ansibleguy.net/en/latest/modules/unbound_dot.html) `domain` is not a required parameter.
An Ansible task without the `domain` parameter set should therefore execute correctly.

# Actual Behavior
The `validate_domain` function called in `unbound_dot.py` will throw an `AttributeError: 'NoneType' object has no attribute 'find'`

# Changes
- `validate_domain` is only called if `domain` is set.
- Opnsense rule matching without `domain` set allows usage of `verify` instead.
- If neither `domain` nor `verify` is set, only `target` parameter is used.

# Discussion
Changing `match_fields` to allow matching only against `target` if neither `domain` nor `verify` is set may lead to ansible operating on the wrong rule, if multiple rules with the same `target` attribute are set.

An alternative approach could be to always require either `verify` or `domain` parameter being set.
However, since both are marked as optional, this will probably not solve the underlying issue.
