### PR TITLE
Update shebangs to match developer guide

### DIFF
--- a/plugins/modules/_tmpl_direct.py
+++ b/plugins/modules/_tmpl_direct.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/_tmpl_obj.py
+++ b/plugins/modules/_tmpl_obj.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/alias.py
+++ b/plugins/modules/alias.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/alias_multi.py
+++ b/plugins/modules/alias_multi.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/alias_purge.py
+++ b/plugins/modules/alias_purge.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/bind_acl.py
+++ b/plugins/modules/bind_acl.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/bind_blocklist.py
+++ b/plugins/modules/bind_blocklist.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/bind_domain.py
+++ b/plugins/modules/bind_domain.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/bind_general.py
+++ b/plugins/modules/bind_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/bind_record.py
+++ b/plugins/modules/bind_record.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/bind_record_multi.py
+++ b/plugins/modules/bind_record_multi.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/cron.py
+++ b/plugins/modules/cron.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bfd_general.py
+++ b/plugins/modules/frr_bfd_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bfd_neighbor.py
+++ b/plugins/modules/frr_bfd_neighbor.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bgp_as_path.py
+++ b/plugins/modules/frr_bgp_as_path.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bgp_community_list.py
+++ b/plugins/modules/frr_bgp_community_list.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bgp_general.py
+++ b/plugins/modules/frr_bgp_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bgp_neighbor.py
+++ b/plugins/modules/frr_bgp_neighbor.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bgp_prefix_list.py
+++ b/plugins/modules/frr_bgp_prefix_list.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_bgp_route_map.py
+++ b/plugins/modules/frr_bgp_route_map.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_diagnostic.py
+++ b/plugins/modules/frr_diagnostic.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_general.py
+++ b/plugins/modules/frr_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf3_general.py
+++ b/plugins/modules/frr_ospf3_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf3_interface.py
+++ b/plugins/modules/frr_ospf3_interface.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf_general.py
+++ b/plugins/modules/frr_ospf_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf_interface.py
+++ b/plugins/modules/frr_ospf_interface.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf_network.py
+++ b/plugins/modules/frr_ospf_network.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf_prefix_list.py
+++ b/plugins/modules/frr_ospf_prefix_list.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_ospf_route_map.py
+++ b/plugins/modules/frr_ospf_route_map.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/frr_rip.py
+++ b/plugins/modules/frr_rip.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_action.py
+++ b/plugins/modules/ids_action.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_general.py
+++ b/plugins/modules/ids_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_policy.py
+++ b/plugins/modules/ids_policy.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_policy_rule.py
+++ b/plugins/modules/ids_policy_rule.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_rule.py
+++ b/plugins/modules/ids_rule.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_ruleset.py
+++ b/plugins/modules/ids_ruleset.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ids_user_rule.py
+++ b/plugins/modules/ids_user_rule.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/interface_vip.py
+++ b/plugins/modules/interface_vip.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/interface_vlan.py
+++ b/plugins/modules/interface_vlan.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/interface_vxlan.py
+++ b/plugins/modules/interface_vxlan.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_auth_local.py
+++ b/plugins/modules/ipsec_auth_local.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_auth_remote.py
+++ b/plugins/modules/ipsec_auth_remote.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_cert.py
+++ b/plugins/modules/ipsec_cert.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_child.py
+++ b/plugins/modules/ipsec_child.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_connection.py
+++ b/plugins/modules/ipsec_connection.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_pool.py
+++ b/plugins/modules/ipsec_pool.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_psk.py
+++ b/plugins/modules/ipsec_psk.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/ipsec_vti.py
+++ b/plugins/modules/ipsec_vti.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/list.py
+++ b/plugins/modules/list.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2024, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/monit_alert.py
+++ b/plugins/modules/monit_alert.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/monit_service.py
+++ b/plugins/modules/monit_service.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/monit_test.py
+++ b/plugins/modules/monit_test.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/nginx_general.py
+++ b/plugins/modules/nginx_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/nginx_upstream_server.py
+++ b/plugins/modules/nginx_upstream_server.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/openvpn_client.py
+++ b/plugins/modules/openvpn_client.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2024, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/openvpn_client_override.py
+++ b/plugins/modules/openvpn_client_override.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2024, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/openvpn_server.py
+++ b/plugins/modules/openvpn_server.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2024, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/openvpn_static_key.py
+++ b/plugins/modules/openvpn_static_key.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2024, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/openvpn_status.py
+++ b/plugins/modules/openvpn_status.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2024, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/package.py
+++ b/plugins/modules/package.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/reload.py
+++ b/plugins/modules/reload.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/rule.py
+++ b/plugins/modules/rule.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/rule_multi.py
+++ b/plugins/modules/rule_multi.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/rule_purge.py
+++ b/plugins/modules/rule_purge.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/savepoint.py
+++ b/plugins/modules/savepoint.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/shaper_pipe.py
+++ b/plugins/modules/shaper_pipe.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/shaper_queue.py
+++ b/plugins/modules/shaper_queue.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/shaper_rule.py
+++ b/plugins/modules/shaper_rule.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/source_nat.py
+++ b/plugins/modules/source_nat.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/syslog.py
+++ b/plugins/modules/syslog.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/system.py
+++ b/plugins/modules/system.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_acl.py
+++ b/plugins/modules/unbound_acl.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_domain.py
+++ b/plugins/modules/unbound_domain.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_dot.py
+++ b/plugins/modules/unbound_dot.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_forward.py
+++ b/plugins/modules/unbound_forward.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_general.py
+++ b/plugins/modules/unbound_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_host.py
+++ b/plugins/modules/unbound_host.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/unbound_host_alias.py
+++ b/plugins/modules/unbound_host_alias.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_acl.py
+++ b/plugins/modules/webproxy_acl.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_auth.py
+++ b/plugins/modules/webproxy_auth.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_cache.py
+++ b/plugins/modules/webproxy_cache.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_forward.py
+++ b/plugins/modules/webproxy_forward.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_general.py
+++ b/plugins/modules/webproxy_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_icap.py
+++ b/plugins/modules/webproxy_icap.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_pac_match.py
+++ b/plugins/modules/webproxy_pac_match.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_pac_proxy.py
+++ b/plugins/modules/webproxy_pac_proxy.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_pac_rule.py
+++ b/plugins/modules/webproxy_pac_rule.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_parent.py
+++ b/plugins/modules/webproxy_parent.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_remote_acl.py
+++ b/plugins/modules/webproxy_remote_acl.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/webproxy_traffic.py
+++ b/plugins/modules/webproxy_traffic.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/wireguard_general.py
+++ b/plugins/modules/wireguard_general.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/wireguard_peer.py
+++ b/plugins/modules/wireguard_peer.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/wireguard_server.py
+++ b/plugins/modules/wireguard_server.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/plugins/modules/wireguard_show.py
+++ b/plugins/modules/wireguard_show.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 # Copyright: (C) 2023, AnsibleGuy <guy@ansibleguy.net>
 # GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)


### PR DESCRIPTION
### Background

The Ansible developer guide give some [pretty specific advice](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding) about the use shebangs in module files. 

> Begin your Ansible module with #!/usr/bin/python - this “shebang” allows ansible_python_interpreter to work.
> [ ... ]
> Using #!/usr/bin/env, makes env the interpreter and bypasses ansible_<interpreter>_interpreter logic.

This actually ended up causing issues for me, possibly because I run ansible in a virtual environment. The error I was getting was something like `/usr/bin/env python3: file or directory not found` (I've lost it in my scrollback unfortunately.)

This guidance is a little counter-intuitive to me, I've always used `/usr/bin/env` to resolve interpreters properly, but it looks like ansible actually handles the shebang itself, instead of leaving it to the shell. 

### Change

- Update shebangs to `#!/usr/bin/python`
- Added the utf-8 coding comment, as recommended in the guide

### Test

I've been using several modules from the updated collection and haven't hit any issues