### PR TITLE
Problem: Multi rule bugs

### DIFF
--- a/plugins/module_utils/helper/main.py
+++ b/plugins/module_utils/helper/main.py
@@ -506,6 +506,6 @@ def unset_check_error(params: dict, field: str, fail: bool) -> bool:
     return True
 
 def sanitize_module_args(args: dict) -> dict:
-    args.pop('api_key')
-    args.pop('api_secret')
+    args.pop('api_key', None)
+    args.pop('api_secret', None)
     return args

--- a/plugins/module_utils/helper/rule.py
+++ b/plugins/module_utils/helper/rule.py
@@ -2,6 +2,8 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.main import \
     get_matching
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.rule import \
+     RULE_DEFAULTS
 
 
 def validate_values(error_func, module: AnsibleModule, cnf: dict) -> None:
@@ -44,6 +46,11 @@ def check_purge_configured(module: AnsibleModule, existing_rule: dict) -> bool:
     for rule_key, rule_config in module.params['rules'].items():
         if rule_config is None:
             rule_config = {}
+
+        rule_config = {
+            **RULE_DEFAULTS,
+            **rule_config,
+        }
 
         rule_config[module.params['key_field']] = rule_key
         configured_rules.append(rule_config)


### PR DESCRIPTION
### Modules

ansibleguy.opnsense.rule_purge

### Version

```
1.2.10
```

### Ansible Version

```bash
2.17.4
```

### OPNSense Version

```
24.7
```

### Issue

We are using `rule_purge` with a `match_fields` which is not in all `rules` it will fail in [get_matching](https://github.com/ansibleguy/collection_opnsense/blob/9b4c34f2a1b267d826c74cf729a5180ac8f2e3e6/plugins/module_utils/helper/main.py#L107-L150) as the [RULE_DEFAULTS](https://github.com/ansibleguy/collection_opnsense/blob/9b4c34f2a1b267d826c74cf729a5180ac8f2e3e6/plugins/module_utils/defaults/rule.py#L4-L24) are not applied. `rule_multi` does [apply the defaults](https://github.com/ansibleguy/collection_opnsense/blob/9b4c34f2a1b267d826c74cf729a5180ac8f2e3e6/plugins/module_utils/main/rule_multi.py#L50).

The [nice error message](https://github.com/ansibleguy/collection_opnsense/blob/9b4c34f2a1b267d826c74cf729a5180ac8f2e3e6/plugins/module_utils/helper/main.py#L140-L143) `get_matching` tries to show in this case leads to a `The error was: KeyError: 'api_key'` as the arguments for the rule do not contain a `api_key` or `api_secret` which [sanitize_module_args](https://github.com/ansibleguy/collection_opnsense/blob/9b4c34f2a1b267d826c74cf729a5180ac8f2e3e6/plugins/module_utils/helper/main.py#L508-L511) insists on removing.