### PR TITLE
Alias urltable dynipv6host

### DIFF
--- a/docs/source/modules/alias.rst
+++ b/docs/source/modules/alias.rst
@@ -42,6 +42,7 @@ Definition
     "content","list","false for state changes, else true","\-","cont, c","Values the alias should hold"
     "type","string","false","'host'","t","Type of value the alias should hold. One of: 'host', 'network', 'port', 'url', 'urltable', 'geoip', 'networkgroup', 'mac', 'dynipv6host', 'internal', 'external'"
     "updatefreq_days","float","false","7.0","\-","Needed only for the alias-type 'urltable'. Interval to update its content. Per example: 0.5 for every 12 hours"
+    "interface","string","false","\-","int, if","Needed only for the alias-type 'dynipv6host'. Select the interface for the V6 dynamic IP"
     "reload","boolean","false","false","\-", .. include:: ../_include/param_reload.rst
 
 .. include:: ../_include/param_basic.rst
@@ -73,6 +74,7 @@ Examples
             state: 'present'
             # type: 'host'  # default
             # updatefreq_days: 3  # used only for type 'urltable'
+            # interface: lan # used only for the type 'dynipv6host'
             # ssl_ca_file: '/etc/ssl/certs/custom/ca.crt'
             # ssl_verify: False
             # api_key: !vault ...  # alternative to 'api_credential_file'

--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -9,6 +9,7 @@ ALIAS_DEFAULTS = {
     'content': [],
     'debug': False,
     'updatefreq_days': 7.0,
+    'interface': None
 }
 
 ALIAS_MOD_ARG_ALIASES = {
@@ -18,6 +19,7 @@ ALIAS_MOD_ARG_ALIASES = {
     'description': ['desc'],
     'state': ['st'],
     'enabled': ['en'],
+    'interface': ['int']
 }
 
 ALIAS_MOD_ARGS = dict(
@@ -38,6 +40,11 @@ ALIAS_MOD_ARGS = dict(
         type='float', default=ALIAS_DEFAULTS['updatefreq_days'], required=False,
         description="Update frequency used by type 'urltable' in days - "
                     "per example '0.5' for 12 hours"
+    ),
+    interface=dict(
+        type='str', default=ALIAS_DEFAULTS['interface'],
+        aliases=ALIAS_MOD_ARG_ALIASES['interface'], required=False,
+        description=' Select the interface for the V6 dynamic IP.',
     ),
     **STATE_MOD_ARG,
     **OPN_MOD_ARGS,

--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -19,7 +19,7 @@ ALIAS_MOD_ARG_ALIASES = {
     'description': ['desc'],
     'state': ['st'],
     'enabled': ['en'],
-    'interface': ['int']
+    'interface': ['int', 'if']
 }
 
 ALIAS_MOD_ARGS = dict(

--- a/tests/alias.yml
+++ b/tests/alias.yml
@@ -245,12 +245,29 @@
         updatefreq_days: 2
         content: 'https://www.spamhaus.org/drop/drop.txt'
 
+    - name: Adding urltable - nothing changed
+      ansibleguy.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_URLTABLE1'
+        type: 'urltable'
+        updatefreq_days: 2
+        content: 'https://www.spamhaus.org/drop/drop.txt'
+      register: opn14
+      failed_when: >
+        opn14.failed or
+        opn14.changed
+      when: not ansible_check_mode
+
     - name: Updating urltable update-frequency
       ansibleguy.opnsense.alias:
         name: 'ANSIBLE_TEST_1_2_URLTABLE1'
         type: 'urltable'
         updatefreq_days: 6.5
         content: 'https://www.spamhaus.org/drop/drop.txt'
+      register: opn15
+      failed_when: >
+        opn15.failed or
+        not opn15.changed
+      when: not ansible_check_mode
 
     - name: Adding multiple urltables
       ansibleguy.opnsense.alias:
@@ -294,6 +311,17 @@
       loop:
         - ['XXX']
 
+    # dynipv6host
+
+    - name: Adding dynipv6host
+      ansibleguy.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_DYNIPV6HOST1'
+        type: 'dynipv6host'
+        content:
+          - '::1000'
+          - '::f00d'
+        interface: 'lan'
+
     # cleanup
 
     - name: Cleanup
@@ -322,6 +350,7 @@
         - 'ANSIBLE_TEST_1_2_GEOIP1'
         - 'ANSIBLE_TEST_1_2_GEOIP2'
         - 'ANSIBLE_TEST_1_2_GEOIP3'
+        - 'ANSIBLE_TEST_1_2_DYNIPV6HOST1'
 
 - name: Testing Alias - listing
   hosts: localhost

--- a/tests/alias_multi.yml
+++ b/tests/alias_multi.yml
@@ -66,6 +66,7 @@
           ANSIBLE_TEST_2_8:
             type: 'urltable'
             content: ['https://www.spamhaus.org/drop/drop.txt', 'https://www.spamhaus.org/drop/edrop.txt']
+            updatefreq_days: 6.5
 
           # geoip
           ANSIBLE_TEST_2_9:
@@ -74,6 +75,14 @@
           ANSIBLE_TEST_2_10:
             type: 'geoip'
             content: ['AT', 'DE', 'CH']
+
+          # dynipv6host
+          ANSIBLE_TEST_2_11:
+            type: 'dynipv6host'
+            content:
+              - '::f00d'
+            interface: 'lan'
+
         reload: false  # geoip and urltable take LONG time
       register: opn2
       failed_when: >
@@ -97,9 +106,16 @@
           ANSIBLE_TEST_2_8:
             type: 'urltable'
             content: 'https://www.spamhaus.org/drop/dropv6.txt'
+            updatefreq_days: 2
           ANSIBLE_TEST_2_9:
             type: 'geoip'
             content: 'DE'
+          ANSIBLE_TEST_2_11:
+            type: 'dynipv6host'
+            content:
+              - '::1000'
+              - '::f00d'
+            interface: 'lan'
         reload: false  # geoip and urltable take LONG time
       register: opn3
       failed_when: >
@@ -123,11 +139,19 @@
             content: 'http://test.template.ansibleguy.net'
           ANSIBLE_TEST_2_8:
             type: 'urltable'
+            updatefreq_days: 2
             content: 'https://www.spamhaus.org/drop/dropv6.txt'
           ANSIBLE_TEST_2_9:
             type: 'geoip'
             content: 'DE'
+          ANSIBLE_TEST_2_11:
+            type: 'dynipv6host'
+            content:
+              - '::1000'
+              - '::f00d'
+            interface: 'lan'
         reload: false  # geoip and urltable take LONG time
+        debug: true
       register: opn6
       failed_when: >
         opn6.failed or
@@ -139,7 +163,7 @@
       register: opn4
       failed_when: >
         'data' not in opn4 or
-        opn4.data | length != 10
+        opn4.data | length != 11
       when: not ansible_check_mode
 
     - name: Removing
@@ -155,6 +179,7 @@
           ANSIBLE_TEST_2_8:
           ANSIBLE_TEST_2_9:
           ANSIBLE_TEST_2_10:
+          ANSIBLE_TEST_2_11:
         state: 'absent'
 
     - name: Checking cleanup


### PR DESCRIPTION
### Modules

* ansibleguy.opnsense.alias
* ansibleguy.opnsense.alias_multi

### Version
latest

### Issue
For alias of the type `urltable` the `updatefreq_days` parameter is not set/updated and alias of the type `dynipv6host` can not be created as as the `interface` parameter is required.