### PR TITLE
Problem: Handle ModuleSoftError in purge.

### DIFF
--- a/plugins/module_utils/helper/purge.py
+++ b/plugins/module_utils/helper/purge.py
@@ -1,4 +1,6 @@
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    ModuleSoftError
 
 
 def purge(
@@ -12,17 +14,20 @@ def purge(
         result['diff']['after'][item_to_purge[diff_param]] = None
 
     if not module.check_mode:
-        _obj = obj_func(item_to_purge)
-        _obj.exists = True
+        try:
+            _obj = obj_func(item_to_purge)
+            _obj.exists = True
 
-        if module.params['action'] == 'delete':
-            _obj.delete()
+            if module.params['action'] == 'delete':
+                _obj.delete()
 
-        else:
-            if _obj.b.is_enabled():
-                result['diff']['before'][item_to_purge[diff_param]] = {'enabled': True}
-                result['diff']['after'][item_to_purge[diff_param]] = {'enabled': False}
-                _obj.b.disable()
+            else:
+                if _obj.b.is_enabled():
+                    result['diff']['before'][item_to_purge[diff_param]] = {'enabled': True}
+                    result['diff']['after'][item_to_purge[diff_param]] = {'enabled': False}
+                    _obj.b.disable()
+        except ModuleSoftError:
+            pass
 
 
 def check_purge_filter(module: AnsibleModule, item: dict) -> bool:

--- a/tests/alias_purge.yml
+++ b/tests/alias_purge.yml
@@ -126,6 +126,31 @@
         opn7.data | length != 1
       when: not ansible_check_mode
 
+    - name: Adding 4
+      ansibleguy.opnsense.alias_multi:
+        aliases:
+          ANSIBLE_TEST_4_1:
+            content: ['192.168.1.1', '192.168.1.2']
+          ANSIBLE_TEST_4_2:
+            content: 'ANSIBLE_TEST_4_1'
+      when: not ansible_check_mode
+
+    - name: Purge used alias
+      ansibleguy.opnsense.alias_purge:
+        aliases:
+          ANSIBLE_TEST_4_2:
+      when: not ansible_check_mode
+      register: opn11
+      failed_when: >
+        opn11.failed or
+        'warnings' not in opn11
+
+    - name: Purge using alias first
+      ansibleguy.opnsense.alias_purge:
+        aliases:
+          ANSIBLE_TEST_4_1:
+      when: not ansible_check_mode
+
     - name: Purge ALL - not forced
       ansibleguy.opnsense.alias_purge:
       when: not ansible_check_mode


### PR DESCRIPTION
 ### Modules
 
 alias_purge

### Version

latest

> ### Ansible Version

-

### OPNSense Version

24.7.11

 ### OPNSense-Plugin Version
 
_No response_

### Issue

When `alias_purge` tries to delete a referenced alias a `ModuleSoftError` is raised from the `delete` method.
https://github.com/ansibleguy/collection_opnsense/blob/ea48c5380b220acfcfd6686e270b389d7433c2d2/plugins/module_utils/main/alias.py#L118-L133

```
TASK [Purge used alias] *********************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler.ModuleSoftError
fatal: [localhost]: FAILED! => {"changed": false, "failed_when_result": true, "module_stderr": "Traceback (most recent call last):
  File \"/tmp/ansible-tmp-17301/AnsiballZ_alias_purge.py\", line 107, in <module>
    _ansiballz_main()
    ~~~~~~~~~~~~~~~^^
  File \"/tmp/ansible-tmp-17301/AnsiballZ_alias_purge.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/tmp/ansible-tmp-17301/AnsiballZ_alias_purge.py\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.ansibleguy.opnsense.plugins.modules.alias_purge', init_globals=dict(_module_fqn='ansible_collections.ansibleguy.opnsense.plugins.modules.alias_purge', _modlib_path=modlib_path),
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     run_name='__main__', alter_sys=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"<frozen runpy>\", line 226, in run_module
  File \"<frozen runpy>\", line 98, in _run_module_code
  File \"<frozen runpy>\", line 88, in _run_code
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/alias_purge.py\", line 77, in <module>
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/alias_purge.py\", line 73, in main
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/alias_purge.py\", line 66, in run_module
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/main/alias_purge.py\", line 80, in process
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/helper/purge.py\", line 21, in purge
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/main/alias.py\", line 122, in delete
  File \"/tmp/ansible_ansibleguy.opnsense.alias_purge_payload_mfg4z4iu/ansible_ansibleguy.opnsense.alias_purge_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/module_utils/main/alias.py\", line 133, in _error
ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler.ModuleSoftError
", "module_stdout": "", "msg": "MODULE FAILURE: No start of json char found
See stdout/stderr for the exact error", "rc": 1}
```

### Config Ansible

-

### Config OPNSense

_No response_
### Debug Output

-

### Profiling Output

_No response_

