### PR TITLE
Problem: package debug mode is broken

### DIFF
--- a/plugins/modules/package.py
+++ b/plugins/modules/package.py
@@ -59,7 +59,6 @@ def run_module():
             check=process, kwargs=dict(
                 m=module, p=module.params, r=result,
             ),
-            log_file='package.log'  # /tmp/ansibleguy.opnsense/
         )
 
     else:


### PR DESCRIPTION
### Modules

ansibleguy.opnsense.package

### Issue

Seting `debug`to `true` for the `ansibleguy.opnsense.package` results in a error.

#### Example call
```
    - name: Installing packages
      ansibleguy.opnsense.package:
        name: os-postfix
        action: 'install'
        debug: true
```


#### STDERR output
```
Traceback (most recent call last):
  File \"/home/marius/.ansible/tmp/ansible-tmp-1740845627.2570596-293035-74816999307085/AnsiballZ_package.py\", line 107, in <module>
    _ansiballz_main()
    ~~~~~~~~~~~~~~~^^
  File \"/home/marius/.ansible/tmp/ansible-tmp-1740845627.2570596-293035-74816999307085/AnsiballZ_package.py\", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/home/marius/.ansible/tmp/ansible-tmp-1740845627.2570596-293035-74816999307085/AnsiballZ_package.py\", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.ansibleguy.opnsense.plugins.modules.package', init_globals=dict(_module_fqn='ansible_collections.ansibleguy.opnsense.plugins.modules.package', _modlib_path=modlib_path),
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     run_name='__main__', alter_sys=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"<frozen runpy>\", line 226, in run_module
  File \"<frozen runpy>\", line 98, in _run_module_code
  File \"<frozen runpy>\", line 88, in _run_code
  File \"/tmp/ansible_ansibleguy.opnsense.package_payload__7dvn8kq/ansible_ansibleguy.opnsense.package_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/package.py\", line 76, in <module>
  File \"/tmp/ansible_ansibleguy.opnsense.package_payload__7dvn8kq/ansible_ansibleguy.opnsense.package_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/package.py\", line 72, in main
  File \"/tmp/ansible_ansibleguy.opnsense.package_payload__7dvn8kq/ansible_ansibleguy.opnsense.package_payload.zip/ansible_collections/ansibleguy/opnsense/plugins/modules/package.py\", line 58, in run_module
TypeError: profiler() got an unexpected keyword argument 'log_file'
```

The `log_file` parameter has been removed in 98b0723