### PR TITLE
Tests housekeeping

### DIFF
--- a/tests/1_dependencies.yml
+++ b/tests/1_dependencies.yml
@@ -27,3 +27,4 @@
         - 'os-bind'
         - 'os-acme-client'
         - 'os-postfix'
+        - 'os-nginx'

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,8 @@ Some tests need packages to be pre-installed:
 * frr_* - `os-frr`
 * bind_* - `os-bind`
 * acme_* - `os-acme-client`
+* postfix_* - `os-postfix`
+* nginx_* - `os-nginx`
 
 See also: `1_dependencies.yml`
 

--- a/tests/wireguard_peer.yml
+++ b/tests/wireguard_peer.yml
@@ -237,7 +237,7 @@
       when: not ansible_check_mode
 
     - name: Cleanup dummy instance
-      ansibleguy.opnsense.wireguard_peer:
+      ansibleguy.opnsense.wireguard_server:
         name: 'ANSIBLE_TEST_2_1'
         state: 'absent'
       when: not ansible_check_mode


### PR DESCRIPTION
### Problem

* The `wireguard_peer` tests do not clean up after them which results in `wireguard_server` failing.
* The list of required plugins is incomplete