### PR TITLE
Fix package state tests (fixes #72 and #159)

### DIFF
--- a/tests/package.yml
+++ b/tests/package.yml
@@ -34,15 +34,14 @@
         opn1.failed or
         opn1.changed
 
-    # todo: fix #159
-    # - name: Removing - does not exist
-    #   ansibleguy.opnsense.package:
-    #     name: "{{ test_app1 }}"
-    #     action: 'remove'
-    #   register: opn2
-    #   failed_when: >
-    #     opn2.failed or
-    #     opn2.changed
+    - name: Removing - does not exist
+      ansibleguy.opnsense.package:
+        name: "{{ test_app1 }}"
+        action: 'remove'
+      register: opn2
+      failed_when: >
+        opn2.failed or
+        opn2.changed
 
     - name: Installing
       ansibleguy.opnsense.package:
@@ -67,15 +66,14 @@
         seconds: 5
       when: not ansible_check_mode
 
-    # see issue #72
-    # - name: Checking if installed
-    #   ansibleguy.opnsense.list:
-    #   register: opn12
-    #   failed_when: >
-    #     opn12.failed or
-    #     test_app1 not in opn12 | json_query('data[*].name') or
-    #     test_app2 not in opn12 | json_query('data[*].name')
-    #   when: not ansible_check_mode
+    - name: Checking if installed
+      ansibleguy.opnsense.list:
+      register: opn12
+      failed_when: >
+        opn12.failed or
+        test_app1 not in opn12.data | map(attribute='name') or
+        test_app2 not in opn12.data | map(attribute='name')
+      when: not ansible_check_mode
 
     - name: Locking
       ansibleguy.opnsense.package:
@@ -125,12 +123,11 @@
         not opn8.changed
       when: not ansible_check_mode
 
-    # todo: fix #159
-    #    - name: Checking if removed
-    #      ansibleguy.opnsense.list:
-    #      register: opn11
-    #      failed_when: >
-    #        opn11.failed or
-    #        test_app1 in opn11 | json_query('data[*].name') or
-    #        test_app2 in opn11 | json_query('data[*].name')
-    #      when: not ansible_check_mode
+    - name: Checking if removed
+      ansibleguy.opnsense.list:
+      register: opn11
+      failed_when: >
+        opn11.failed or
+        test_app1 in opn11.data | map(attribute='name') or
+        test_app2 in opn11.data | map(attribute='name')
+      when: not ansible_check_mode


### PR DESCRIPTION
The test is unable to locate `json_query` aka
`community.general.json_query` as collection `community.general` is missing.