### PR TITLE
Secrets leakage in wireguard module - private_key, psk

### DIFF
--- a/plugins/modules/wireguard_peer.py
+++ b/plugins/modules/wireguard_peer.py
@@ -29,7 +29,7 @@ def run_module():
     module_args = dict(
         name=dict(type='str', required=True),
         public_key=dict(type='str', required=False, alises=['pubkey', 'pub']),
-        psk=dict(type='str', required=False),
+        psk=dict(type='str', required=False, no_log=True),
         allowed_ips=dict(
             type='list', elements='str', required=False, default=[],
             aliases=[

--- a/plugins/modules/wireguard_server.py
+++ b/plugins/modules/wireguard_server.py
@@ -29,7 +29,7 @@ def run_module():
     module_args = dict(
         name=dict(type='str', required=True),
         public_key=dict(type='str', required=False, alises=['pubkey', 'pub']),
-        private_key=dict(type='str', required=False, alises=['privkey', 'priv']),
+        private_key=dict(type='str', required=False, no_log=True, alises=['privkey', 'priv']),
         port=dict(type='int', required=False),
         mtu=dict(type='int', required=False, default=1420),
         dns_servers=dict(


### PR DESCRIPTION
Fix for WireGuard module leaking private_key and psk into logs.