### PR TITLE
Problem: OpenVPN Client/Server not working after changes to search API

### DIFF
--- a/plugins/module_utils/base/base.py
+++ b/plugins/module_utils/base/base.py
@@ -113,8 +113,8 @@ class Base:
                     )
 
                 data.append({
-                    **detail_entry,
                     **base_entry,
+                    **detail_entry,
                 })
                 if self.raw is None:
                     self.raw = data[0]

--- a/plugins/module_utils/main/ipsec_manual_spd.py
+++ b/plugins/module_utils/main/ipsec_manual_spd.py
@@ -31,7 +31,7 @@ class ManualSPD(BaseModule):
     FIELDS_TYPING = {
         'bool': ['enabled'],
         'list': [],
-        'select': [],
+        'select': ['connection_child'],
         'int': ['request_id'],
     }
     INT_VALIDATIONS = {
@@ -42,7 +42,6 @@ class ManualSPD(BaseModule):
     def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
         BaseModule.__init__(self=self, m=module, r=result, s=session)
         self.spd = {}
-        self.existing_childs = None
 
     def check(self) -> None:
         if self.p['state'] == 'present':
@@ -50,13 +49,12 @@ class ManualSPD(BaseModule):
 
         self._base_check()
 
-    def _build_request(self) -> dict:
-        self.b.find_single_link(
-            field='connection_child',
-            existing=self.search_connection_child(),
-            existing_field_id='value',
-        )
-        return self.b.build_request()
+        if self.p['state'] == 'present':
+            self.b.find_single_link(
+                field='connection_child',
+                existing=self.search_connection_child(),
+                existing_field_id='value',
+            )
 
     def search_connection_child(self) -> dict:
         return self.s.get(cnf={


### PR DESCRIPTION
### Modules

* ansibleguy.opnsense.openvpn_server
* ansibleguy.opnsense.openvpn_client

### Version

latest

### Ansible Version

```
$ ansible --version
ansible [core 2.18.4]
  config file = None
  configured module search path = ['/home/mrieder/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mrieder/collection_opnsense/venv/lib/python3.12/site-packages/ansible
  ansible collection location = /home/mrieder/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/mrieder/collection_opnsense/venv/bin/ansible
  python version = 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] (/home/mrieder/collection_opnsense/venv/bin/python3)
  jinja version = 3.1.6
  libyaml = True
```

### OPNSense Version

25.1.5_5

### Issue

The `openvpn/instance/search` api got much more verbose, returning many more fields. Now (for example) `verb` (aka: `log_level`) is set in the search is set to 

```
"3 (Normal)"
```

while the modules expect it to be 

```
{
	"verb": [
		{
			"value": "0 (No output except fatal errors.)",
			"selected": 0
		},
		{
			"value": "1 (Normal)",
			"selected": 0
		},
		{
			"value": "2 (Normal)",
			"selected": 0
		},
		{
			"value": "3 (Normal)",
			"selected": 1
		},
...
		{
			"value": "11 (debug)",
			"selected": 0
		}
	]
}
```

This leads to an exception in `get_selected_opt_list_idx` during the simplification.

Switching the merge order to prefer values from the deail/get endpoint over search solve this issue.


#### 25.1 /api/openvpn/instances/search/
```
{
	"rows": [
		{
			"uuid": "e7f2e34d-734b-49cd-bd74-4c6cc4d8239b",
			"description": "sadf",
			"role": "Server",
			"dev_type": "TUN",
			"enabled": "1"
		}
	],
	"rowCount": 1,
	"total": 1,
	"current": 1
}

```

#### 25.1.5_5 /api/openvpn/instances/search/
```
{
	"rows": [
		{
			"uuid": "e7f2e34d-734b-49cd-bd74-4c6cc4d8239b",
			"vpnid": "1",
			"enabled": "1",
			"dev_type": "TUN",
			"verb": "3 (Normal)",
			"proto": "UDP",
			"port": "",
			"local": "",
			"topology": "subnet",
			"remote": "",
			"role": "Server",
			"server": "172.17.34.1",
			"server_ipv6": "",
			"bridge_gateway": "",
			"bridge_pool": "",
			"route": "",
			"push_route": "",
			"cert": "None",
			"crl": "None",
			"ca": "",
			"cert_depth": "Do Not Check",
			"remote_cert_tls": "0",
			"verify_client_cert": "none",
			"use_ocsp": "0",
			"auth": "OpenVPN default",
			"data-ciphers": "",
			"data-ciphers-fallback": "None",
			"tls_key": "",
			"authmode": "Local Database",
			"local_group": "None",
			"various_flags": "",
			"various_push_flags": "",
			"push_inactive": "",
			"username_as_common_name": "0",
			"strictusercn": "No",
			"username": "",
			"password": "",
			"maxclients": "",
			"keepalive_interval": "",
			"keepalive_timeout": "",
			"reneg-sec": "",
			"auth-gen-token": "",
			"auth-gen-token-renewal": "",
			"auth-gen-token-secret": "",
			"provision_exclusive": "0",
			"redirect_gateway": "",
			"route_metric": "",
			"register_dns": "0",
			"dns_domain": "",
			"dns_domain_search": "",
			"dns_servers": "",
			"ntp_servers": "",
			"tun_mtu": "",
			"fragment": "",
			"mssfix": "0",
			"carp_depend_on": "None",
			"description": "sadf",
			"compress_migrate": "0",
			"ifconfig-pool-persist": "0",
			"http-proxy": ""
		}
	],
	"rowCount": 1,
	"total": 1,
	"current": 1
}
```