### PR TITLE
Problem: Fix redistribute parameter for ospf/ospf3

### DIFF
--- a/docs/source/modules/frr_ospf.md
+++ b/docs/source/modules/frr_ospf.md
@@ -122,7 +122,7 @@ For basic parameters see: [Basics](https://opnsense.ansibleguy.net/usage/2_basic
 
 | Parameter      | Type    | Required | Default value | Aliases | Comment |
 |:---------------|:--------|:---------|:--------------|:--------|:--------|
-| redistribution | string  | false    | -             | -       | Select routing sources to redistribute to other nodes. One of: 'ospf', 'connected', 'kernel', 'rip' or 'static'. |
+| redistribution | string  | false    | -             | -       | Select routing sources to redistribute to other nodes. One of: 'bgp', 'connected', 'kernel', 'rip' or 'static'. |
 | description    | string  | true     | -             | desc    | Description for this distribution. |
 | route_map      | string  | false    | -             | map, rm | Optional Route-map to apply to this redistribution. |
 | reload         | boolean | false    | true          | -       | If the running config should be reloaded on change - this will take some time. You might want to reload it 'manually' after all changes are done => using the [reload module](https://opnsense.ansibleguy.net/modules/2_reload.html). |
@@ -197,7 +197,7 @@ For basic parameters see: [Basics](https://opnsense.ansibleguy.net/usage/2_basic
 
 | Parameter      | Type    | Required | Default value | Aliases | Comment |
 |:---------------|:--------|:---------|:--------------|:--------|:--------|
-| redistribution | string  | false    | -             | -       | Select routing sources to redistribute to other nodes. One of: 'ospf', 'connected', 'kernel', 'rip' or 'static'. |
+| redistribution | string  | false    | -             | -       | Select routing sources to redistribute to other nodes. One of: 'bgp', 'connected', 'kernel', 'rip' or 'static'. |
 | description    | string  | true     | -             | desc    | Description for this distribution. |
 | route_map      | string  | false    | -             | map, rm | Optional Route-map to apply to this redistribution. |
 | reload         | boolean | false    | true          | -       | If the running config should be reloaded on change - this will take some time. You might want to reload it 'manually' after all changes are done => using the [reload module](https://opnsense.ansibleguy.net/modules/2_reload.html). |

--- a/plugins/modules/frr_ospf3_redistribution.py
+++ b/plugins/modules/frr_ospf3_redistribution.py
@@ -28,7 +28,7 @@ except MODULE_EXCEPTIONS:
 
 def run_module():
     module_args = dict(
-        redistribute=dict(type='str', required=False, choices=['ospf', 'connected', 'kernel', 'rip', 'static']),
+        redistribute=dict(type='str', required=False, choices=['bgp', 'connected', 'kernel', 'rip', 'static']),
         description=dict(type='str', required=False, aliases=['desc']),
         route_map=dict(
             type='str', required=False, aliases=['map', 'rm']

--- a/plugins/modules/frr_ospf_redistribution.py
+++ b/plugins/modules/frr_ospf_redistribution.py
@@ -27,7 +27,7 @@ except MODULE_EXCEPTIONS:
 
 def run_module():
     module_args = dict(
-        redistribute=dict(type='str', required=False, choices=['ospf', 'connected', 'kernel', 'rip', 'static']),
+        redistribute=dict(type='str', required=False, choices=['bgp', 'connected', 'kernel', 'rip', 'static']),
         description=dict(type='str', required=False, aliases=['desc']),
         route_map=dict(
             type='str', required=False, aliases=['map', 'rm']

--- a/tests/frr_ospf3_redistribution.yml
+++ b/tests/frr_ospf3_redistribution.yml
@@ -40,7 +40,7 @@
     - name: Adding 1 - failing because of non-existent route-map
       ansibleguy.opnsense.frr_ospf3_redistribution:
         description: 'ANSIBLE_TEST_1_1'
-        redistribute: ospf
+        redistribute: bgp
         route_map: 'DOES-NOT-EXIST'
       register: opn_fail2
       failed_when: not opn_fail2.failed
@@ -48,7 +48,7 @@
     - name: Adding 1
       ansibleguy.opnsense.frr_ospf3_redistribution:
         description: 'ANSIBLE_TEST_1_1'
-        redistribute: ospf
+        redistribute: bgp
       register: opn1
       failed_when: >
         opn1.failed or
@@ -98,7 +98,7 @@
     - name: Adding 2
       ansibleguy.opnsense.frr_ospf3_redistribution:
         description: 'ANSIBLE_TEST_1_2'
-        redistribute: ospf
+        redistribute: bgp
       register: opn6
       failed_when: >
         opn6.failed or
@@ -107,7 +107,7 @@
     - name: Adding 2 - nothing changed
       ansibleguy.opnsense.frr_ospf3_redistribution:
         description: 'ANSIBLE_TEST_1_2'
-        redistribute: ospf
+        redistribute: bgp
       register: opn7
       failed_when: >
         opn7.failed or
@@ -180,7 +180,7 @@
     - name: Adding redistribution linked to route-map
       ansibleguy.opnsense.frr_ospf3_redistribution:
         description: 'ANSIBLE_TEST_2_1'
-        redistribute: ospf
+        redistribute: bgp
         route_map: 'ANSIBLE_TEST_3_1'
       register: opn10
       failed_when: >

--- a/tests/frr_ospf_redistribution.yml
+++ b/tests/frr_ospf_redistribution.yml
@@ -40,7 +40,7 @@
     - name: Adding 1 - failing because of non-existent route-map
       ansibleguy.opnsense.frr_ospf_redistribution:
         description: 'ANSIBLE_TEST_1_1'
-        redistribute: ospf
+        redistribute: bgp
         route_map: 'DOES-NOT-EXIST'
       register: opn_fail2
       failed_when: not opn_fail2.failed
@@ -48,7 +48,7 @@
     - name: Adding 1
       ansibleguy.opnsense.frr_ospf_redistribution:
         description: 'ANSIBLE_TEST_1_1'
-        redistribute: ospf
+        redistribute: bgp
       register: opn1
       failed_when: >
         opn1.failed or
@@ -98,7 +98,7 @@
     - name: Adding 2
       ansibleguy.opnsense.frr_ospf_redistribution:
         description: 'ANSIBLE_TEST_1_2'
-        redistribute: ospf
+        redistribute: bgp
       register: opn6
       failed_when: >
         opn6.failed or
@@ -107,7 +107,7 @@
     - name: Adding 2 - nothing changed
       ansibleguy.opnsense.frr_ospf_redistribution:
         description: 'ANSIBLE_TEST_1_2'
-        redistribute: ospf
+        redistribute: bgp
       register: opn7
       failed_when: >
         opn7.failed or
@@ -180,7 +180,7 @@
     - name: Adding redistribution linked to route-map
       ansibleguy.opnsense.frr_ospf_redistribution:
         description: 'ANSIBLE_TEST_2_1'
-        redistribute: ospf
+        redistribute: bgp
         route_map: 'ANSIBLE_TEST_3_1'
       register: opn10
       failed_when: >


### PR DESCRIPTION
### Modules

* ansibleguy.opnsense.frr_ospf_redistribution
* ansibleguy.opnsense.frr_ospf3_redistribution

### Version

```
directly installed from git
```

### OPNSense Version

```
25.1.5_5
```

### OPNSense-Plugin Version

```
os-frr 1.44_1
```

### Issue

`ospf` is not a valid option for the `redistribute` any more and has been replaced with `bgp`.

https://github.com/opnsense/plugins/commit/a6b126270144cd257005a1f5f92e375742edf472

### Debug output

```
TASK [Adding 1] ***********************************************************************************************************************************************************************************************************************************************
[WARNING]: REQUEST: GET | URL: https://172.25.16.1/api/quagga/ospfsettings/get
[WARNING]: RESPONSE: '{'status_code': 200, '_request': <Request('GET', 'https://172.25.16.1/api/quagga/ospfsettings/get')>, '_num_bytes_downloaded': 531, '_elapsed': datetime.timedelta(microseconds=60636), '_content': b'{"ospf":{"enabled":"0","carp_demot
e":"0","routerid":"","costreference":"","logadjacencychanges":"0","originate":"0","originatealways":"0","originatemetric":"","passiveinterfaces":{"enc0":{"value":"IPsec","selected":0},"lan":{"value":"lan","selected":0},"lo0":{"value":"Loopback","selected
":0},"openvpn":{"value":"OpenVPN","selected":0},"opt1":{"value":"opt1","selected":0}},"networks":{"network":[]},"interfaces":{"interface":[]},"prefixlists":{"prefixlist":[]},"routemaps":{"routemap":[]},"redistributions":{"redistribution":[]}}}'}'
[WARNING]: REQUEST: POST | URL: https://172.25.16.1/api/quagga/ospfsettings/addRedistribution | HEADERS: '{'Content-Type': 'application/json'}' | DATA: '{"redistribution": {"enabled": 1, "description": "ANSIBLE_TEST_1_1", "redistribute": "ospf",
"linkedRoutemap": ""}}'
[WARNING]: RESPONSE: '{'status_code': 200, '_request': <Request('POST', 'https://172.25.16.1/api/quagga/ospfsettings/addRedistribution')>, '_num_bytes_downloaded': 87, '_elapsed': datetime.timedelta(microseconds=67377), '_content':
b'{"result":"failed","validations":{"redistribution.redistribute":"Option not in list."}}'}'
fatal: [localhost]: FAILED! => {"changed": false, "failed_when_result": true, "msg": "API call failed | Error: {'redistribution.redistribute': 'Option not in list.'} | Response: {'status_code': 200, 'headers': Headers({'expires': 'Thu, 19 Nov 1981 08:52:00 GMT', 'cache-control': 'no-store, no-cache, must-revalidate', 'pragma': 'no-cache', 'content-type': 'application/json; charset=UTF-8', 'transfer-encoding': 'chunked', 'date': 'Wed, 16 Apr 2025 11:49:47 GMT', 'server': 'OPNsense'}), '_request': <Request('POST', 'https://172.25.16.1/api/quagga/ospfsettings/addRedistribution')>, 'next_request': None, 'extensions': {'http_version': b'HTTP/1.1', 'reason_phrase': b'OK', 'network_stream': <httpcore._backends.sync.SyncStream object at 0x7f06bc13f470>}, 'history': [], 'is_closed': True, 'is_stream_consumed': True, 'default_encoding': 'utf-8', 'stream': <httpx._client.BoundSyncStream object at 0x7f06bc5b4c80>, '_num_bytes_downloaded': 87, '_decoder': <httpx._decoders.IdentityDecoder object at 0x7f06bbe00c50>, '_elapsed': datetime.timedelta(microseconds=67377), '_content': b'{\"result\":\"failed\",\"validations\":{\"redistribution.redistribute\":\"Option not in list.\"}}'}"}
```