### PR TITLE
fix: snapshot test fixes (#205)

### DIFF
--- a/docs/source/modules/3_raw.rst
+++ b/docs/source/modules/3_raw.rst
@@ -2,9 +2,9 @@
 
 .. include:: ../_include/head.rst
 
-===
-Raw
-===
+=======
+3 - Raw
+=======
 
 **STATE**: unstable
 
@@ -36,7 +36,7 @@ You need to either provide :code:`module + controller + command` or :code:`url`!
     :widths: 15 10 10 10 10 45
 
     "module","string","false","\-","m, mod","The API-module to target"
-    "controller","string","false","\-","co, cont","The API-controller to target
+    "controller","string","false","\-","co, cont","The API-controller to target"
     "command","string","false","\-","c, cmd","The API-command to target"
     "parameters","string","false","\-","p, params","Optional: Parameters to send"
     "url","string","false","\-","u","Alternative to module/controller/command</params>"

--- a/docs/source/modules/snapshot.rst
+++ b/docs/source/modules/snapshot.rst
@@ -44,7 +44,7 @@ Info
 Usage
 *****
 
-Allows you to create, activate and delete snapshots. Activation only marks the snapshot as thje default boot option.
+Allows you to create, activate and delete snapshots. Activation only marks the snapshot as the default boot option.
 It does **not** change the snapshot currently running.
 
 Examples

--- a/plugins/module_utils/main/snapshot.py
+++ b/plugins/module_utils/main/snapshot.py
@@ -28,7 +28,7 @@ class Snapshot(BaseModule):
     def check(self) -> None:
         self._base_check()
 
-        if self.p['activate'] and 'R' not in self.snapshot['active']:
+        if self.p['activate'] and 'active' in self.snapshot and 'R' not in self.snapshot['active']:
             self.activate()
 
     def _search_call(self) -> dict:
@@ -36,6 +36,10 @@ class Snapshot(BaseModule):
             **self.call_cnf,
             'command': self.CMDS['search'],
         })['rows']
+
+    def _ensure_zfs(self, resp: dict):
+        if resp['result'] == 'Unsupported root filesystem':
+            self.m.fail_json('Unsupported => Snapshots require a ZFS filesystem!')
 
     def create(self) -> dict:
         self.r['changed'] = True
@@ -47,6 +51,7 @@ class Snapshot(BaseModule):
                 'data': {'name': self.p['name']},
             })
             if resp['status'] != 'ok':
+                self._ensure_zfs(resp)
                 self.m.fail_json(f"Failed creating snapshot '{self.p['name']}'")
 
     def update(self) -> dict:
@@ -62,4 +67,5 @@ class Snapshot(BaseModule):
                 'params': self.snapshot['uuid'],
             })
             if resp['status'] != 'ok':
+                self._ensure_zfs(resp)
                 self.m.fail_json(f"Failed activating snapshot '{self.p['name']}'")

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,6 +92,10 @@ You can provide your backup firewall connection via env-vars:
   * `TEST_HASYNC_USERNAME`
   * `TEST_HASYNC_PASSWORD`
 
+## Snapshots
+
+To run snapshot tests - the target firewall needs to be installed with a ZFS filesystem!
+
 ----
 
 ## Run

--- a/tests/snapshot.yml
+++ b/tests/snapshot.yml
@@ -13,9 +13,22 @@
       target: 'snapshot'
 
   tasks:
+    - name: Checking filesystem (only works for ZFS)
+      ansibleguy.opnsense.snapshot:
+        name: 'ANSIBLE_TEST_1_1'
+      failed_when: false
+      check_mode: false
+      changed_when: false
+      register: opn_test
+
+    - name: Setting filesystem status
+      ansible.builtin.set_fact:
+        opn_zfs: "{{ 'Unsupported' not in opn_test.msg }}"
+
     - name: Listing
       ansibleguy.opnsense.list:
       register: opn_pre1
+      when: opn_zfs | bool
       failed_when: >
         'data' not in opn_pre1 or
         opn_pre1.data | length != 1
@@ -25,6 +38,7 @@
         name: 'ANSIBLE_TEST_1_1'
         state: 'absent'
       register: opn_pre2
+      when: opn_zfs | bool
       failed_when: >
         opn_pre2.failed or
         opn_pre2.changed
@@ -34,12 +48,15 @@
         name: 'INVALID NAME'
       register: opn_fail1
       failed_when: not opn_fail1.failed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Adding 1
       ansibleguy.opnsense.snapshot:
         name: 'ANSIBLE_TEST_1_1'
       register: opn1
+      when: opn_zfs | bool
       failed_when: >
         opn1.failed or
         not opn1.changed
@@ -51,7 +68,9 @@
       failed_when: >
         opn2.failed or
         not opn2.changed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Adding 2 - nothing changed
       ansibleguy.opnsense.snapshot:
@@ -60,7 +79,9 @@
       failed_when: >
         opn3.failed or
         opn3.changed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Activate 2
       ansibleguy.opnsense.snapshot:
@@ -70,7 +91,9 @@
       failed_when: >
         opn4.failed or
         not opn4.changed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Removing 2
       ansibleguy.opnsense.snapshot:
@@ -80,7 +103,9 @@
       failed_when: >
         not opn5.failed or
         opn5.changed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Activate default
       ansibleguy.opnsense.snapshot:
@@ -90,7 +115,9 @@
       failed_when: >
         opn6.failed or
         not opn6.changed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Removing 2
       ansibleguy.opnsense.snapshot:
@@ -100,7 +127,9 @@
       failed_when: >
         opn7.failed or
         not opn7.changed
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Listing
       ansibleguy.opnsense.list:
@@ -108,7 +137,9 @@
       failed_when: >
         'data' not in opn8 or
         opn8.data | length != 2
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Cleanup
       ansibleguy.opnsense.snapshot:
@@ -117,7 +148,9 @@
       loop:
         - 'ANSIBLE_TEST_1_1'
         - 'ANSIBLE_TEST_1_2'
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode
 
     - name: Listing
       ansibleguy.opnsense.list:
@@ -125,4 +158,6 @@
       failed_when: >
         'data' not in opn_clean1 or
         opn_clean1.data | length != 1
-      when: not ansible_check_mode
+      when:
+        - opn_zfs | bool
+        - not ansible_check_mode


### PR DESCRIPTION
Errors of test #205
* Handle if not ZFS
* `opnsense/plugins/module_utils/main/snapshot.py\\\", line 31, in check\\nKeyError: 'active'`