### PR TITLE
Added the parameters tag and tagged for the rule module

### DIFF
--- a/docs/source/modules/rule.rst
+++ b/docs/source/modules/rule.rst
@@ -93,6 +93,8 @@ Definition
     "destination_port","string","false","\-","dp, dest_port","Leave empty to allow all, valid port-number, name, alias or range"
     "gateway","string","false","\-","g, gw","Existing gateway to use"
     "log","boolean","false","true","l","If rule matches should be shown in the firewall logs"
+    "tag","string","false","\-","\-","Packets matching this rule will be tagged with the specified string"
+    "tagged","string","false","\-","\-","Packets must already be tagged with the given tag in order to match the rule"
     "description","string","false","\-","desc","Description for the rule"
     "state","string","false","'present'","st","State of the rule. One of: 'present', 'absent'"
     "enabled","boolean","false","true","en","If the rule should be en- or disabled"
@@ -155,6 +157,8 @@ Basic
             # source_port: ''
             # destination_invert: false
             # log: true
+            # tag: ''
+            # tagged: ''
             # gateway: 'LAN_GW'
             # state: 'present'
             # enabled: true

--- a/plugins/module_utils/defaults/rule.py
+++ b/plugins/module_utils/defaults/rule.py
@@ -17,6 +17,8 @@ RULE_DEFAULTS = {
     'destination_port': '',
     'gateway': '',
     'log': True,
+    'tag': '',
+    'tagged': '',
     'state': 'present',
     'enabled': True,
     'description': '',
@@ -114,6 +116,8 @@ RULE_MOD_ARGS = dict(
         aliases=RULE_MOD_ARG_ALIASES['gateway'], description='Existing gateway to use'
     ),
     log=dict(type='bool', required=False, default=RULE_DEFAULTS['log'], aliases=RULE_MOD_ARG_ALIASES['log'],),
+    tag=dict(type='str', required=False, default=RULE_DEFAULTS['tag'],),
+    tagged=dict(type='str', required=False, default=RULE_DEFAULTS['tagged'],),
     description=dict(
         type='str', required=False, default=RULE_DEFAULTS['description'],
         aliases=RULE_MOD_ARG_ALIASES['description']

--- a/plugins/module_utils/main/rule.py
+++ b/plugins/module_utils/main/rule.py
@@ -25,7 +25,7 @@ class Rule(BaseModule):
         'sequence', 'action', 'quick', 'interface', 'direction',
         'ip_protocol', 'protocol', 'source_invert', 'source_net', 'source_port',
         'destination_invert', 'destination_net', 'destination_port', 'log',
-        'description', 'gateway',
+        'tag', 'tagged', 'description', 'gateway',
     ]
     FIELDS_ALL = ['enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)


### PR DESCRIPTION
I have been utilizing the opnsense collection for firewall administration for quite a while now. Recently, I needed the features for local tags and noticed that they were absent from the collection although the API offered them.

This pull request contains minimal changes to add the two parameters. I verified it with my local firewall instance.

This is my first contribution, so I hope I did not overlook something obvious.
If you need me to change more, I am happy to be pointed in the right direction.