### PR TITLE
Feature: Implement (most) rule features implemented in 25.1

### DIFF
--- a/docs/source/modules/nat_source.rst
+++ b/docs/source/modules/nat_source.rst
@@ -30,7 +30,7 @@ This plugin has some limitations you need to know of:
 * each of these parameters only takes ONE value per rule:
 
   * port
-  * protocol (*or 'any'; 'TCP/UDP' is NOT valid*)
+  * protocol (*or 'any'*)
   * ip-protocol (*IPv4/IPv6*)
 
 * the ruleset managed by this plugin is SEPARATE from the default WEB-UI rules (*Firewall - NAT - Outbound*) - combined usage might bring complications
@@ -71,7 +71,7 @@ Module alias: ansibleguy.opnsense.snat
     "sequence","int","false","1","seq","Sequence for rule processing, Integer between 1 and 1000000"
     "interface","string","false for deletion, else true","\-","i, int","The interface to match this rule on"
     "ip_protocol","string","false","'inet'","ipp, ip_proto","IP protocol to match. One of: 'inet', 'inet6' (*IPv4 = 'inet', IPv6 = 'inet6'*)"
-    "protocol","string","false","'any'","p, proto","Protocol like 'TCP', 'UDP', 'ICMP' and so on. For options see the WEB-UI. 'TCP/UDP' is NOT valid!"
+    "protocol","string","false","'any'","p, proto","Protocol like 'TCP', 'UDP', 'ICMP' and so on. For options see the WEB-UI."
     "source_invert","boolean","false","false","si, src_inv, src_not","Inverted matching of the source"
     "source_net","string","false","'any'","s, src, source","Host, network, alias or 'any'"
     "source_port","string","false","\-","sp, src_port","Leave empty to allow all, alias not supported"

--- a/docs/source/modules/rule.rst
+++ b/docs/source/modules/rule.rst
@@ -82,6 +82,7 @@ Definition
     "action","string","false","'pass'","a","Rule action. One of: 'pass', 'block' or 'reject'"
     "quick","boolean","false","true","q","When set to quick, the rule is handled on “first match” basis, which means that the first rule matching the packet will take precedence over rules following in sequence."
     "interface","list","false","['lan']","i, int","One or multiple interfaces use this rule on"
+    "interface_invert","boolean","false","false","int_inv, ii, int_not","Use all but selected interfaces"
     "direction","string","false","'in'","d, dir","Direction of the traffic. Traffic IN is coming into the firewall interface, while traffic OUT is going out of the firewall interface. In visual terms: [Source] -> IN -> [Firewall] -> OUT -> [Destination]. The default policy is to filter inbound traffic, which means the policy applies to the interface on which the traffic is originally received by the firewall from the source. This is more efficient from a traffic processing perspective. In most cases, the default policy will be the most appropriate."
     "ip_protocol","string","false","'inet'","ipp, ip_proto","IP protocol to match. One of: 'inet', 'inet6' (*IPv4 = 'inet', IPv6 = 'inet6'*)"
     "protocol","string","false","'any'","p, proto","Protocol like 'TCP', 'UDP', 'ICMP' and so on. For options see the WEB-UI."
@@ -92,9 +93,31 @@ Definition
     "destination_net","string","false","'any'","d, dest, destination","Host, network, alias or 'any'"
     "destination_port","string","false","\-","dp, dest_port","Leave empty to allow all, valid port-number, name, alias or range"
     "gateway","string","false","\-","g, gw","Existing gateway to use"
+    "replyto","string","false","\-","rt","Determines how packets route back in the opposite direction"
+    "disable_replyto","boolean","false","false","\-","Explicit disable reply-to for this rule"
     "log","boolean","false","true","l","If rule matches should be shown in the firewall logs"
+    "allow_opts","boolean","false","false","opts","Allows packets with IP options to pass"
+    "state_type","string","false","keep","\-","State tracking mechanism to use. One of: 'keep', 'sloppy', 'modulate', 'synproxy' or 'none'"
+    "state_policy","string","false","''","\-","State tracking mechanism to use. One of: '', 'if-bound', 'floating'"
+    "state_timeout","int","false","\-","\-","State Timeout in seconds (TCP only)"
+    "max_states","int","false","\-","\-","Limits the number of concurrent states"
+    "max_src_nodes","int","false","\-","\-","Limits the number of source addresses which can simultaneously have state table entries"
+    "max_src_states","int","false","\-","\-","Limits the number of simultaneous state entries that a single source address can create"
+    "max_src_conn","int","false","\-","\-","Limit the number of simultaneous TCP connections a single host can make"
+    "max_src_conn_rate","int","false","\-","\-","Maximum new connections per host, measured over time"
+    "max_src_conn_rates","int","false","\-","\-","Time interval (seconds) to measure the number of connections"
+    "overload","int","false","\-","ol","Overload table used when max new connections per time interval has been reached"
+    "adaptive_start","int","false","\-","\-","When the number of state entries exceeds this value, adaptive scaling begins. All timeout values are scaled linearly with factor (adaptive.end - number of states) / (adaptive.end - adaptive.start)"
+    "adaptive_end","int","false","\-","\-","When reaching this number of state entries, all timeout values become zero, effectively purging all state entries immediately. This value is used to define the scale factor, it should not actually be reached (set a lower state limit)"
+    "prio","string","false","\-","\-","Match packets which have the given queueing priority assigned. One of: '', '0', '1', '2', '3', '4', '5', '6', '7'"
+    "set_prio","string","false","\-","\-","Assigne a specific queueing priority. One of: '', '0', '1', '2', '3', '4', '5', '6', '7'"
+    "set_prio_low","string","false","\-","\-","Assigne a specific queueing priority to packets which have a TOS of lowdelay and TCP ACKs with no data payload. One of: '', '0', '1', '2', '3', '4', '5', '6', '7'"
     "tag","string","false","\-","\-","Packets matching this rule will be tagged with the specified string"
     "tagged","string","false","\-","\-","Packets must already be tagged with the given tag in order to match the rule"
+    "tcp_flags","list","false","\-","\-","TCP flags that must be set for this rule to match. Selection of: 'syn', 'ack', 'fin', 'rst', 'psh', 'urg', 'ece', 'cwr'"
+    "tcp_flags_clear","list","false","\-","\-","TCP flags that must be cleared for this rule to match. Selection of: 'syn', 'ack', 'fin', 'rst', 'psh', 'urg', 'ece', 'cwr'"
+    "schedule","string","false","\-","sched","Match packets during the given schedule"
+    "tos","string","false","\-","\-","Match packets which have the given TOS/DCSP assigned"
     "description","string","false","\-","desc","Description for the rule"
     "state","string","false","'present'","st","State of the rule. One of: 'present', 'absent'"
     "enabled","boolean","false","true","en","If the rule should be en- or disabled"
@@ -151,15 +174,38 @@ Basic
             # action: 'pass'
             # quick: true
             # interface: 'lan'
+            # interface_invert: false
             # direction: 'in'
             # ip_protocol: 'inet' or 'inet6'
             # source_invert: false
             # source_port: ''
             # destination_invert: false
+            # gateway: 'LAN_GW'
+            # replyto: ''
+            # disable_replyto: false
             # log: true
+            # allow_opts: false
+            # state_type: keep
+            # state_policy: None
+            # state_timeout: None
+            # max_states: None
+            # max_src_nodes: None
+            # max_src_states: None
+            # max_src_conn: None
+            # max_src_conn_rate: None
+            # max_src_conn_rates: None
+            # overload: None
+            # adaptive_start: None
+            # adaptive_end: None
+            # prio: ''
+            # set_prio: ''
+            # set_prio_low: ''
             # tag: ''
             # tagged: ''
-            # gateway: 'LAN_GW'
+            # tcp_flags: None
+            # tcp_flags_clear: None
+            # schedule: None
+            # tos: None
             # state: 'present'
             # enabled: true
             # uuid: 'a9d85c00-0aa2-4705-b855-96aae16e05d7'  # optionally use uuid to identify existing rules

--- a/docs/source/modules/rule.rst
+++ b/docs/source/modules/rule.rst
@@ -29,7 +29,7 @@ This plugin has some limitations you need to know of:
 * each of these parameters only takes ONE value per rule:
 
   * port (*port-number, name, alias or range*)
-  * protocol (*or 'any'; 'TCP/UDP' is NOT valid*)
+  * protocol (*or 'any'*)
   * ip-protocol (*IPv4/IPv6*)
   * direction
 
@@ -84,7 +84,7 @@ Definition
     "interface","list","false","['lan']","i, int","One or multiple interfaces use this rule on"
     "direction","string","false","'in'","d, dir","Direction of the traffic. Traffic IN is coming into the firewall interface, while traffic OUT is going out of the firewall interface. In visual terms: [Source] -> IN -> [Firewall] -> OUT -> [Destination]. The default policy is to filter inbound traffic, which means the policy applies to the interface on which the traffic is originally received by the firewall from the source. This is more efficient from a traffic processing perspective. In most cases, the default policy will be the most appropriate."
     "ip_protocol","string","false","'inet'","ipp, ip_proto","IP protocol to match. One of: 'inet', 'inet6' (*IPv4 = 'inet', IPv6 = 'inet6'*)"
-    "protocol","string","false","'any'","p, proto","Protocol like 'TCP', 'UDP', 'ICMP' and so on. For options see the WEB-UI. 'TCP/UDP' is NOT valid!"
+    "protocol","string","false","'any'","p, proto","Protocol like 'TCP', 'UDP', 'ICMP' and so on. For options see the WEB-UI."
     "source_invert","boolean","false","false","si, src_inv, src_not","Inverted matching of the source"
     "source_net","string","false","'any'","s, src, source","Host, network, alias or 'any'"
     "source_port","string","false","\-","sp, src_port","Leave empty to allow all, valid port-number, name, alias or range"

--- a/plugins/module_utils/defaults/rule.py
+++ b/plugins/module_utils/defaults/rule.py
@@ -6,6 +6,7 @@ RULE_DEFAULTS = {
     'action': 'pass',
     'quick': True,
     'interface': ['lan'],
+    'interface_invert': False,
     'direction': 'in',
     'ip_protocol': 'inet',
     'protocol': 'any',
@@ -16,9 +17,31 @@ RULE_DEFAULTS = {
     'destination_net': 'any',
     'destination_port': '',
     'gateway': '',
+    'replyto': '',
+    'disable_replyto': False,
     'log': True,
+    'allow_opts': False,
+    'state_type': 'keep',
+    'state_policy': '',
+    'state_timeout': None,
+    'max_states': None,
+    'max_src_nodes': None,
+    'max_src_states': None,
+    'max_src_conn': None,
+    'max_src_conn_rate': None,
+    'max_src_conn_rates': None,
+    'overload': None,
+    'adaptive_start': None,
+    'adaptive_end': None,
+    'prio': '',
+    'set_prio': '',
+    'set_prio_low': '',
     'tag': '',
     'tagged': '',
+    'tcp_flags': [],
+    'tcp_flags_clear': [],
+    'schedule': '',
+    'tos': '',
     'state': 'present',
     'enabled': True,
     'description': '',
@@ -30,6 +53,7 @@ RULE_MOD_ARG_ALIASES = {
     'action': ['a'],
     'quick': ['q'],
     'interface': ['int', 'i'],
+    'interface_invert': ['int_inv', 'ii', 'int_not'],
     'direction': ['dir'],
     'ip_protocol': ['ip', 'ip_proto'],
     'protocol': ['proto', 'p'],
@@ -40,7 +64,11 @@ RULE_MOD_ARG_ALIASES = {
     'destination_net': ['destination', 'dest', 'd'],
     'destination_port': ['dest_port', 'dp'],
     'gateway': ['gw', 'g'],
+    'replyto': ['rt'],
     'log': ['l'],
+    'allow_opts': ['opts'],
+    'overload': ['ol'],
+    'schedule': ['sched'],
     'description': ['desc'],
     'state': ['st'],
     'enabled': ['en'],
@@ -72,6 +100,10 @@ RULE_MOD_ARGS = dict(
     interface=dict(
         type='list', required=False, default=RULE_DEFAULTS['interface'], aliases=RULE_MOD_ARG_ALIASES['interface'],
         description='One or multiple interfaces use this rule on', elements='str',
+    ),
+    interface_invert=dict(
+        type='bool', required=False, default=RULE_DEFAULTS['interface_invert'],
+        aliases=RULE_MOD_ARG_ALIASES['interface_invert'],
     ),
     direction=dict(
         type='str', required=False, default=RULE_DEFAULTS['direction'], aliases=RULE_MOD_ARG_ALIASES['direction'],
@@ -115,9 +147,97 @@ RULE_MOD_ARGS = dict(
         type='str', required=False, default=RULE_DEFAULTS['gateway'],
         aliases=RULE_MOD_ARG_ALIASES['gateway'], description='Existing gateway to use'
     ),
+    replyto=dict(
+        type='str', required=False, default=RULE_DEFAULTS['replyto'],
+        aliases=RULE_MOD_ARG_ALIASES['replyto'],
+        description='Determines how packets route back in the opposite direction'
+    ),
+    disable_replyto=dict(
+        type='bool', required=False, default=RULE_DEFAULTS['disable_replyto'],
+        description='Explicit disable reply-to for this rule'
+    ),
     log=dict(type='bool', required=False, default=RULE_DEFAULTS['log'], aliases=RULE_MOD_ARG_ALIASES['log'],),
+    allow_opts=dict(
+        type='bool', required=False, default=RULE_DEFAULTS['allow_opts'], aliases=RULE_MOD_ARG_ALIASES['allow_opts'],
+        description='Allows packets with IP options to pass'
+    ),
+    state_type=dict(
+        type='str', required=False, default=RULE_DEFAULTS['state_type'],
+        choices=['keep', 'sloppy', 'modulate', 'synproxy', 'none'],
+        description='State tracking mechanism to use'
+    ),
+    state_policy=dict(
+        type='str', required=False, default=RULE_DEFAULTS['state_policy'],
+        choices=['', 'if-bound', 'floating'], description='State tracking mechanism to use'
+    ),
+    state_timeout=dict(
+        type='int', required=False,
+        description='State Timeout in seconds (TCP only)'
+    ),
+    max_states=dict(type='int', required=False, description='Limits the number of concurrent states',),
+    max_src_nodes=dict(
+        type='int', required=False,
+        description='Limits the number of source addresses which can simultaneously have state table entries'
+    ),
+    max_src_states=dict(
+        type='int', required=False,
+        description='Limits the number of simultaneous state entries that a single source address can create'
+    ),
+    max_src_conn=dict(
+        type='int', required=False,
+        description='Limit the number of simultaneous TCP connections a single host can make'
+    ),
+    max_src_conn_rate=dict(
+        type='int', required=False,
+        description='Maximum new connections per host, measured over time'
+    ),
+    max_src_conn_rates=dict(
+        type='int', required=False,
+        description='Time interval (seconds) to measure the number of connections'
+    ),
+    overload=dict(
+        type='str', required=False,
+        aliases=RULE_MOD_ARG_ALIASES['overload'],
+        description='Overload table used when max new connections per time interval has been reached'
+    ),
+    adaptive_start=dict(type='int', required=False,),
+    adaptive_end=dict(type='int', required=False,),
+    prio=dict(
+        type='str', required=False, default=RULE_DEFAULTS['prio'],
+        choices=['', '0', '1', '2', '3', '4', '5', '6', '7'],
+        description='Match packets which have the given queueing priority assigned'
+    ),
+    set_prio=dict(
+        type='str', required=False, default=RULE_DEFAULTS['set_prio'],
+        choices=['', '0', '1', '2', '3', '4', '5', '6', '7'],
+        description='Assigne a specific queueing priority'
+    ),
+    set_prio_low=dict(
+        type='str', required=False, default=RULE_DEFAULTS['set_prio_low'],
+        choices=['', '0', '1', '2', '3', '4', '5', '6', '7'],
+        description='Assigne a specific queueing priority to packets which have a TOS of lowdelay '
+                    'and TCP ACKs with no data payload'
+    ),
     tag=dict(type='str', required=False, default=RULE_DEFAULTS['tag'],),
     tagged=dict(type='str', required=False, default=RULE_DEFAULTS['tagged'],),
+    tcp_flags=dict(
+        type='list', elements='str', required=False, default=RULE_DEFAULTS['tcp_flags'],
+        choices=['syn', 'ack', 'fin', 'rst', 'psh', 'urg', 'ece', 'cwr'],
+        description='TCP flags that must be set for this rule to match'
+    ),
+    tcp_flags_clear=dict(
+        type='list', elements='str', required=False, default=RULE_DEFAULTS['tcp_flags_clear'],
+        choices=['syn', 'ack', 'fin', 'rst', 'psh', 'urg', 'ece', 'cwr'],
+        description='TCP flags that must be cleared for this rule to match'
+    ),
+    schedule=dict(
+        type='str', required=False, default=RULE_DEFAULTS['schedule'],
+        aliases=RULE_MOD_ARG_ALIASES['schedule'],
+    ),
+    tos=dict(
+        type='str', required=False, default=RULE_DEFAULTS['tos'],
+        description='Match packets which have the given TOS/DCSP assigned'
+    ),
     description=dict(
         type='str', required=False, default=RULE_DEFAULTS['description'],
         aliases=RULE_MOD_ARG_ALIASES['description']

--- a/plugins/module_utils/helper/rule.py
+++ b/plugins/module_utils/helper/rule.py
@@ -22,11 +22,8 @@ def validate_values(error_func, module: AnsibleModule, cnf: dict) -> None:
     #             except ValueError:
     #                 error_func(error % (cnf[field], field))
 
-    if cnf['protocol'] in ['TCP/UDP']:
-        error_func(error % (cnf['protocol'], 'protocol'))
-
     # some recommendations - maybe the user overlooked something
-    if 'action' in cnf and cnf['action'] == 'pass' and cnf['protocol'] in ['TCP', 'UDP']:
+    if 'action' in cnf and cnf['action'] == 'pass' and cnf['protocol'] in ['TCP', 'UDP', 'TCP/UDP']:
         if cnf['source_net'] == 'any' and cnf['destination_net'] == 'any':
             module.warn(
                 "Configuring allow-rules with 'any' source and "

--- a/plugins/module_utils/helper/rule.py
+++ b/plugins/module_utils/helper/rule.py
@@ -7,7 +7,7 @@ from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.rule 
 
 
 def validate_values(error_func, module: AnsibleModule, cnf: dict) -> None:
-    error = "Value '%s' is invalid for the field '%s'!"
+    # error = "Value '%s' is invalid for the field '%s'!"
 
     # can't validate as aliases are supported
     # for field in ['source_net', 'destination_net']:
@@ -21,6 +21,17 @@ def validate_values(error_func, module: AnsibleModule, cnf: dict) -> None:
     #
     #             except ValueError:
     #                 error_func(error % (cnf[field], field))
+
+    required_together=[
+        ('max_src_conn_rate', 'max_src_conn_rates', 'overload'),
+        ('adaptive_start', 'adaptive_end'),
+        ('tcp_flags', 'tcp_flags_clear'),
+    ]
+    for opts in required_together:
+        if any((cnf[opts[0]] is None) != (cnf[o] is None) for o in opts[1:]):
+            error_func(f"parameters are required together: {', '.join(opts)}")
+        if any((cnf[opts[0]] == []) != (cnf[o] == []) for o in opts[1:]):
+            error_func(f"parameters are required together: {', '.join(opts)}")
 
     # some recommendations - maybe the user overlooked something
     if 'action' in cnf and cnf['action'] == 'pass' and cnf['protocol'] in ['TCP', 'UDP', 'TCP/UDP']:

--- a/plugins/module_utils/main/rule.py
+++ b/plugins/module_utils/main/rule.py
@@ -22,27 +22,58 @@ class Rule(BaseModule):
     API_MOD = 'firewall'
     API_CONT = 'filter'
     FIELDS_CHANGE = [
-        'sequence', 'action', 'quick', 'interface', 'direction',
+        'sequence', 'action', 'quick', 'interface', 'interface_invert', 'direction',
         'ip_protocol', 'protocol', 'source_invert', 'source_net', 'source_port',
         'destination_invert', 'destination_net', 'destination_port', 'log',
-        'tag', 'tagged', 'description', 'gateway',
+        'tag', 'tagged', 'description', 'gateway', 'replyto', 'disable_replyto',
+        'allow_opts', 'state_type', 'state_policy', 'state_timeout',
+        'max_states', 'max_src_nodes', 'max_src_states', 'max_src_conn', 'max_src_conn_rate',
+        'max_src_conn_rates', 'overload', 'adaptive_start', 'adaptive_end', 'prio', 'set_prio', 'set_prio_low',
+        'tcp_flags', 'tcp_flags_clear', 'schedule', 'tos',
     ]
     FIELDS_ALL = ['enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)
     FIELDS_TRANSLATE = {
+        'interface_invert': 'interfacenot',
         'ip_protocol': 'ipprotocol',
         'source_invert': 'source_not',
         'destination_invert': 'destination_not',
+        'disable_replyto': 'disablereplyto',
+        'allow_opts': 'allowopts',
+        'state_type': 'statetype',
+        'state_policy': 'state-policy',
+        'state_timeout': 'statetimeout',
+        'max_states': 'max',
+        'max_src_nodes': 'max-src-nodes',
+        'max_src_states': 'max-src-states',
+        'max_src_conn': 'max-src-conn',
+        'max_src_conn_rate': 'max-src-conn-rate',
+        'max_src_conn_rates': 'max-src-conn-rates',
+        'adaptive_start': 'adaptivestart',
+        'adaptive_end': 'adaptiveend',
+        'set_prio': 'set-prio',
+        'set_prio_low': 'set-prio-low',
+        'tcp_flags': 'tcpflags1',
+        'tcp_flags_clear': 'tcpflags2',
+        'schedule': 'sched',
     }
     FIELDS_TYPING = {
-        'bool': ['enabled', 'log', 'quick', 'source_invert', 'destination_invert'],
-        'select': ['action', 'direction', 'ip_protocol', 'protocol', 'gateway'],
-        'list': ['interface'],
+        'bool': [
+            'enabled', 'log', 'quick', 'interface_invert', 'source_invert', 'destination_invert', 'disable_replyto',
+            'allow_opts',
+        ],
+        'select': [
+            'action', 'direction', 'ip_protocol', 'protocol', 'gateway', 'replyto', 'state_type', 'state_policy',
+            'overload', 'prio', 'set_prio', 'set_prio_low', 'schedule', 'tos', 'shaper1', 'shaper2',
+        ],
+        'list': ['interface', 'tcp_flags', 'tcp_flags_clear'],
+        'int': ['sequence', 'state_timeout'],
     }
     EXIST_ATTR = 'rule'
     TIMEOUT = 60.0  # urltable etc reload
     INT_VALIDATIONS = {
         'sequence': {'min': 1, 'max': 99999},
+        'state_timeout': {'min': 1},
     }
     API_CMD_REL = 'apply'
 

--- a/plugins/module_utils/main/rule_multi.py
+++ b/plugins/module_utils/main/rule_multi.py
@@ -65,6 +65,10 @@ def process(m: AnsibleModule, p: dict, r: dict) -> None:
             # NOTE: parameter type-casting not done automatically
             if 'interface' in real_cnf and isinstance(real_cnf['interface'], str):
                 real_cnf['interface'] = [real_cnf['interface']]
+            if 'tcp_flags' in real_cnf and isinstance(real_cnf['tcp_flags'], str):
+                real_cnf['tcp_flags'] = [real_cnf['tcp_flags']]
+            if 'tcp_flags_clear' in real_cnf and isinstance(real_cnf['tcp_flags_clear'], str):
+                real_cnf['tcp_flags_clear'] = [real_cnf['tcp_flags_clear']]
 
             valid_rules[rule_key] = real_cnf
 

--- a/tests/nat_source.yml
+++ b/tests/nat_source.yml
@@ -32,16 +32,6 @@
         opn_pre2.failed or
         opn_pre2.changed
 
-    - name: Adding 1 - failing because of invalid protocol
-      ansibleguy.opnsense.source_nat:
-        description: 'ANSIBLE_TEST_1_1'
-        interface: 'lan'
-        destination: '192.168.0.1'
-        target: '192.168.0.2'
-        protocol: 'TCP/UDP'
-      register: opn_fail1
-      failed_when: not opn_fail1.failed
-
     - name: Adding 1 - failing because of invalid alias (server-side)
       ansibleguy.opnsense.source_nat:
         description: 'ANSIBLE_TEST_1_1'

--- a/tests/rule.yml
+++ b/tests/rule.yml
@@ -454,3 +454,182 @@
       failed_when: >
         'data' not in opn16 or
         opn16.data | length != 0
+
+- name: Testing Rules - Advanced Mode
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    ansibleguy.opnsense.rule:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+      match_fields: ['description']
+
+  tasks:
+    - name: Adding 1 - failing because of invalid value
+      ansibleguy.opnsense.rule:
+        tcp_flags: syn
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn_fail1
+      failed_when: not opn_fail1.failed
+      ignore_errors: true
+
+    - name: Adding Filter
+      ansibleguy.opnsense.rule:
+        protocol: TCP
+        allow_opts: true
+        tcp_flags: syn
+        tcp_flags_clear: ack
+        description: 'ANSIBLE_TEST_4_1'
+
+    - name: Updating Filter - nothing changed
+      ansibleguy.opnsense.rule:
+        protocol: TCP
+        allow_opts: true
+        tcp_flags: syn
+        tcp_flags_clear: ack
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn1
+      failed_when: >
+        opn1.failed or
+        opn1.changed
+      when: not ansible_check_mode
+
+    - name: Updating Stateful firewall
+      ansibleguy.opnsense.rule:
+        protocol: TCP
+        state_type: sloppy
+        state_policy: floating
+        state_timeout: 42
+        max_src_nodes: 43
+        max_src_states: 44
+        max_src_conn: 45
+        max_src_conn_rate: 46
+        max_src_conn_rates: 47
+        overload: virusprot
+        adaptive_start: 48
+        adaptive_end: 99
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn2
+      failed_when: >
+        opn2.failed or
+        not opn2.changed
+
+    - name: Updating Stateful firewall - nothing changed
+      ansibleguy.opnsense.rule:
+        protocol: TCP
+        state_type: sloppy
+        state_policy: floating
+        state_timeout: 42
+        max_src_nodes: 43
+        max_src_states: 44
+        max_src_conn: 45
+        max_src_conn_rate: 46
+        max_src_conn_rates: 47
+        overload: virusprot
+        adaptive_start: 48
+        adaptive_end: 99
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn3
+      failed_when: >
+        opn3.failed or
+        opn3.changed
+      when: not ansible_check_mode
+
+    - name: Updating Source Routing firewall
+      ansibleguy.opnsense.rule:
+        gateway: TEST-GW
+        replyto: TEST-GW
+        disable_replyto: true
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn4
+      failed_when: >
+        opn4.failed or
+        not opn4.changed
+
+    - name: Updating Source Routing - nothing changed
+      ansibleguy.opnsense.rule:
+        gateway: TEST-GW
+        replyto: TEST-GW
+        disable_replyto: true
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn5
+      failed_when: >
+        opn5.failed or
+        opn5.changed
+      when: not ansible_check_mode
+
+    - name: Updating Internal tagging
+      ansibleguy.opnsense.rule:
+        tagged: ansible
+        tag: ansible
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn6
+      failed_when: >
+        opn6.failed or
+        not opn6.changed
+
+    - name: Updating Internal tagging - nothing changed
+      ansibleguy.opnsense.rule:
+        tagged: ansible
+        tag: ansible
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn7
+      failed_when: >
+        opn7.failed or
+        opn7.changed
+      when: not ansible_check_mode
+
+    - name: Updating Priority
+      ansibleguy.opnsense.rule:
+        prio: 1
+        set_prio: 2
+        set_prio_low: 3
+        tos: af42
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn8
+      failed_when: >
+        opn8.failed or
+        not opn8.changed
+
+    - name: Updating Priority - nothing changed
+      ansibleguy.opnsense.rule:
+        prio: 1
+        set_prio: 2
+        set_prio_low: 3
+        tos: af42
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn9
+      failed_when: >
+        opn9.failed or
+        opn9.changed
+      when: not ansible_check_mode
+
+    - name: Updating Internal tagging
+      ansibleguy.opnsense.rule:
+        tagged: ansible
+        tag: ansible
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn10
+      failed_when: >
+        opn10.failed or
+        not opn10.changed
+
+    - name: Updating Internal tagging - nothing changed
+      ansibleguy.opnsense.rule:
+        tagged: ansible
+        tag: ansible
+        description: 'ANSIBLE_TEST_4_1'
+      register: opn11
+      failed_when: >
+        opn11.failed or
+        opn11.changed
+      when: not ansible_check_mode
+
+    - name: Cleanup
+      ansibleguy.opnsense.rule:
+        description: "{{ item }}"
+        state: 'absent'
+      diff: false
+      loop:
+        - 'ANSIBLE_TEST_4_1'

--- a/tests/rule_multi.yml
+++ b/tests/rule_multi.yml
@@ -24,6 +24,8 @@
           ANSIBLE_TEST_2_2:
           ANSIBLE_TEST_2_3:
           ANSIBLE_TEST_2_4:
+          ANSIBLE_TEST_2_5:
+          ANSIBLE_TEST_2_6:
         state: 'absent'
       register: opn1
       failed_when: >
@@ -138,6 +140,59 @@
       failed_when: not opn6.failed
       when: not ansible_check_mode
 
+    - name: Adding 3 - Advanced Mode
+      ansibleguy.opnsense.rule_multi:
+        rules:
+          ANSIBLE_TEST_2_5:
+            allow_opts: true
+            tcp_flags: syn
+            tcp_flags_clear: ack
+            protocol: 'TCP'
+          ANSIBLE_TEST_2_6:
+            protocol: TCP
+            state_type: sloppy
+            state_policy: floating
+            state_timeout: 42
+            max_src_nodes: 43
+            max_src_states: 44
+            max_src_conn: 45
+            max_src_conn_rate: 46
+            max_src_conn_rates: 47
+            overload: virusprot
+            adaptive_start: 48
+            adaptive_end: 99
+      register: opn10
+      failed_when: >
+        opn10.failed or
+        not opn10.changed
+
+    - name: Changing 3 - Advanced Mode - not changed
+      ansibleguy.opnsense.rule_multi:
+        rules:
+          ANSIBLE_TEST_2_5:
+            allow_opts: true
+            tcp_flags: syn
+            tcp_flags_clear: ack
+            protocol: 'TCP'
+          ANSIBLE_TEST_2_6:
+            protocol: TCP
+            state_type: sloppy
+            state_policy: floating
+            state_timeout: 42
+            max_src_nodes: 43
+            max_src_states: 44
+            max_src_conn: 45
+            max_src_conn_rate: 46
+            max_src_conn_rates: 47
+            overload: virusprot
+            adaptive_start: 48
+            adaptive_end: 99
+      when: not ansible_check_mode
+      register: opn11
+      failed_when: >
+        opn11.failed or
+        opn11.changed
+
     # noting to validate..
     # - name: Fail on client-side validation
     #   ansibleguy.opnsense.rule_multi:
@@ -166,7 +221,7 @@
       register: opn4
       failed_when: >
         'data' not in opn4 or
-        opn4.data | length != 4
+        opn4.data | length != 6
       when: not ansible_check_mode
 
     - name: Removing
@@ -176,6 +231,8 @@
           ANSIBLE_TEST_2_2:
           ANSIBLE_TEST_2_3:
           ANSIBLE_TEST_2_4:
+          ANSIBLE_TEST_2_5:
+          ANSIBLE_TEST_2_6:
         state: 'absent'
 
     - name: Checking cleanup


### PR DESCRIPTION
Implement most of the new features/options for rules implemented in  OPNsense 25.1

Still missing are:
 * `pf_sync` and `ha_sync`` due to https://github.com/O-X-L/ansible-opnsense/issues/228
 * `categories` and traffic shaping as more api interaction is required to resolve the names into ids

