### PR TITLE
fix: New search api forces detail call on all items

### DIFF
--- a/plugins/module_utils/base/base.py
+++ b/plugins/module_utils/base/base.py
@@ -699,9 +699,6 @@ class Base:
         if hasattr(self.i, '_search_call'):
             return self.i._search_call()
 
-        if hasattr(self.i, 'search_call'):
-            return self.i.search_call()
-
         return self.search(match_fields)
 
     def _api_headers(self) -> dict:

--- a/plugins/module_utils/base/base.py
+++ b/plugins/module_utils/base/base.py
@@ -111,13 +111,13 @@ class Base:
                             'params': [base_entry[self.field_pk]]
                         })
                     )
+                    if self.raw is None:
+                        self.raw = detail_entry
 
                 data.append({
                     **base_entry,
                     **detail_entry,
                 })
-                if self.raw is None:
-                    self.raw = data[0]
 
             if self.raw is None:
                 self.raw = self._search_path_handling(

--- a/plugins/module_utils/base/cls.py
+++ b/plugins/module_utils/base/cls.py
@@ -56,9 +56,6 @@ class BaseModule(BaseShared):
     def __init__(self, m: AnsibleModule, r: dict, s: Session = None):
         super().__init__(m, r, s)
 
-    def _search_call(self) -> list:
-        return self.b.search()
-
     def _base_check(self, match_fields: list = None):
         self._check_validators()
 

--- a/plugins/module_utils/main/ipsec_cert.py
+++ b/plugins/module_utils/main/ipsec_cert.py
@@ -66,8 +66,8 @@ class KeyPair(BaseModule):
         # makes processing easier
         simple = {
             'type': get_selected(key['keyType']),
-            'public_key': key['publicKey'].strip(),
-            'private_key': key['privateKey'].strip(),
+            'public_key': key.get('publicKey', '').strip(),
+            'private_key': key.get('privateKey', '').strip(),
             'name': key['name'],
         }
 


### PR DESCRIPTION
### Modules

All modules using the new search api who relay on `_base_check` and do not implement `_search_call` themselves.

### Issue

#### TLDR

The `match_fields` is lost on the way provoking the new search logic to call the detail endpoint for all instances.

#### Detail

The method `BaseModule._base_check` build the `match_fields` list and passes this list on to `Base.find`

https://github.com/O-X-L/ansible-opnsense/blob/625338cd23506b8cee6920819a51c6cc15d3c9cb/plugins/module_utils/base/cls.py#L62-L78

The method `Base.find` passes the `match_fields` on to `Base._call_search`

https://github.com/O-X-L/ansible-opnsense/blob/625338cd23506b8cee6920819a51c6cc15d3c9cb/plugins/module_utils/base/base.py#L181-L183

The method `Base._call_search` find a `_search_call` method on every Instance, as [BaseModule](https://github.com/O-X-L/ansible-opnsense/blob/625338cd23506b8cee6920819a51c6cc15d3c9cb/plugins/module_utils/base/cls.py#L59) (and [GeneralModule](https://github.com/O-X-L/ansible-opnsense/blob/625338cd23506b8cee6920819a51c6cc15d3c9cb/plugins/module_utils/base/cls.py#L118)) implement/provide this method. However the carefully constructed  `match_fields` is not passed on.

https://github.com/O-X-L/ansible-opnsense/blob/625338cd23506b8cee6920819a51c6cc15d3c9cb/plugins/module_utils/base/base.py#L698-L700

This prevent the Base.search method to check  if all the `match_fields` are matching as it did not get the `match_fields`passed on any more. And therefor has to call the `detail` endpoint for each item.

https://github.com/O-X-L/ansible-opnsense/blob/625338cd23506b8cee6920819a51c6cc15d3c9cb/plugins/module_utils/base/base.py#L99-L101

While the module works fine, it takes more api calls and time to complete then necessary.