### PR TITLE
Fixed Issue #245 - ip_protocol: ipv46

### DIFF
--- a/plugins/module_utils/defaults/rule.py
+++ b/plugins/module_utils/defaults/rule.py
@@ -110,8 +110,8 @@ RULE_MOD_ARGS = dict(
         choices=['in', 'out']
     ),
     ip_protocol=dict(
-        type='str', required=False, choices=['inet', 'inet6'],
-        default=RULE_DEFAULTS['ip_protocol'], description="IPv4 = 'inet', IPv6 = 'inet6'",
+        type='str', required=False, choices=['inet', 'inet6', 'inet46'],
+        default=RULE_DEFAULTS['ip_protocol'], description="IPv4 = 'inet', IPv6 = 'inet6', 'IPv4+6 = 'inet46'",
         aliases=RULE_MOD_ARG_ALIASES['ip_protocol'],
     ),
     protocol=dict(


### PR DESCRIPTION
Added Choice 'ipv46' for ip_protocol to create Firewallrules matching IPv4 and IPv6 Traffic.
Added value according to the OPNsense API.