### PR TITLE
fix: acme_certificate reporting changed, when not changed #264

### DIFF
--- a/plugins/module_utils/main/acme_certificate.py
+++ b/plugins/module_utils/main/acme_certificate.py
@@ -39,7 +39,7 @@ class Certificate(BaseModule):
     FIELDS_TYPING = {
         'bool': ['enabled', 'auto_renewal', 'ocsp'],
         'list': ['alt_names', 'restart_actions'],
-        'select': ['account', 'validation', 'restart_actions', 'aliasmode'],
+        'select': ['account', 'validation', 'restart_actions', 'aliasmode', 'key_length'],
         'int': ['renew_interval'],
     }
     INT_VALIDATIONS = {


### PR DESCRIPTION
Fixes #264 

Ok, I think this is just a regression of my other PR #251. Seems like I missed setting the field type to 'select'. 