### PR TITLE
fix(alias): handle updatefreq_days for host type alias

### DIFF
--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -55,6 +55,10 @@ class Alias(BaseModule):
             if not is_unset(self.p['updatefreq_days']):
                 self.p['updatefreq_days'] = float(self.p['updatefreq_days'])
 
+        if self.p["type"] == "host":
+            self.FIELDS_CHANGE = self.FIELDS_CHANGE + ["updatefreq_days"]
+            self.p["updatefreq_days"] = ""
+
         if self.p['type'] == 'dynipv6host':
             if is_unset(self.p['interface']):
                 self.m.fail_json('You need to provide an interface to create a dynipv6host alias!')


### PR DESCRIPTION
The Host alias api support an updatefreq value. It's hidden in the UI and only used for hostname aliases.

We should not set it to use the default opnsense value. Without this change updatefreq_days is set to 7 and hostnames used as alias are only update every week.