### PR TITLE
feat : add haproxy module

### DIFF
--- a/docs/source/modules/haproxy_acl.rst
+++ b/docs/source/modules/haproxy_acl.rst
@@ -1,0 +1,167 @@
+.. _modules_haproxy_acl:
+
+.. include:: ../_include/head.rst
+
+===========
+HAProxy ACL
+===========
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_acl.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","ACL name"
+    "description","string","false","\-","\-","ACL description"
+    "enabled","boolean","false","true","\-","Enable or disable ACL"
+    "expression","string","true","\-","\-","ACL expression type. One of: 'http_auth', 'hdr_beg', 'hdr_end', 'hdr', 'hdr_reg', 'hdr_sub', 'path_beg', 'path_end', 'path', 'path_reg', 'path_dir', 'path_sub', 'cust_hdr_beg', 'cust_hdr_end', 'cust_hdr', 'cust_hdr_reg', 'cust_hdr_sub', 'url_param', 'ssl_c_verify', 'ssl_c_verify_code', 'ssl_c_ca_commonname', 'ssl_hello_type', 'src', 'src_is_local', 'src_port', 'src_bytes_in_rate', 'src_bytes_out_rate', 'src_kbytes_in', 'src_kbytes_out', 'src_conn_cnt', 'src_conn_cur', 'src_conn_rate'"
+    "value","string","false","\-","\-","ACL match value (required for most expressions, except 'ssl_c_verify', 'src_is_local', and 'http_auth')"
+    "negate","boolean","false","false","\-","Negate the ACL condition"
+    "case_sensitive","boolean","false","true","\-","Case sensitive matching"
+    "allowedUsers","list","false","\-","\-","**NEW**: List of user names for HTTP auth - supports automatic UUID resolution"
+    "allowedGroups","list","false","\-","\-","**NEW**: List of group names for HTTP auth - supports automatic UUID resolution"
+
+Usage
+*****
+
+This module manages HAProxy Access Control Lists (ACLs) on OPNsense. ACLs allow you to create rules that match client requests based on various criteria such as headers, paths, source IP addresses, SSL properties, and authentication.
+
+Key features:
+
+- **Automatic UUID Resolution**: All relationship fields accept names and automatically resolve to UUIDs
+- **Name-based Linking**: Users can specify user names and group names instead of UUIDs
+- **UI Compatibility**: All selections appear correctly in the OPNsense web interface
+- **Multi-select Support**: Lists support multiple items with proper comma-separated format
+- **Flexible expressions**: Support for HTTP headers, paths, SSL properties, source matching, and authentication
+- **Authentication ACLs**: Integrate with HAProxy users and groups for HTTP authentication
+- **Pattern matching**: Support for regular expressions, case-sensitive/insensitive matching, and negation
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_acl'
+
+      tasks:
+        - name: Create path-based ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'api_path'
+            description: 'Match API paths'
+            enabled: true
+            expression: 'path_beg'
+            value: '/api/'
+
+        - name: Create source IP ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'internal_ips'
+            description: 'Match internal IP addresses'
+            enabled: true
+            expression: 'src'
+            value: '192.168.1.0/24'
+
+        - name: Create HTTP auth ACL with name-based user/group linking
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'admin_auth'
+            description: 'Admin authentication'
+            enabled: true
+            expression: 'http_auth'
+            allowedUsers: ['admin', 'operator', 'superuser']  # Uses user names, not UUIDs
+            allowedGroups: ['administrators', 'power_users']  # Uses group names, not UUIDs
+
+        - name: Create SSL client verification ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'valid_client_cert'
+            description: 'Client has valid SSL certificate'
+            enabled: true
+            expression: 'ssl_c_verify'
+            value: '0'  # 0 means certificate is valid
+
+        - name: Create custom header ACL with case-insensitive matching
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'api_token_present'
+            description: 'API token header present'
+            enabled: true
+            expression: 'cust_hdr'
+            value: 'X-API-Token'
+            case_sensitive: false
+
+        - name: Create source rate limiting ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'rate_limited'
+            description: 'Source exceeds rate limit'
+            enabled: true
+            expression: 'src_conn_rate'
+            value: '10'
+
+        - name: Create negated path ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'not_static_content'
+            description: 'Not static content paths'
+            enabled: true
+            expression: 'path_beg'
+            value: '/static/'
+            negate: true
+
+        - name: Create URL parameter ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'debug_mode'
+            description: 'Debug parameter present'
+            enabled: true
+            expression: 'url_param'
+            value: 'debug'
+
+        - name: Create complex authentication ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'privileged_access'
+            description: 'Privileged user authentication'
+            enabled: true
+            expression: 'http_auth'
+            allowedUsers: ['admin']
+            allowedGroups: ['security_team', 'infrastructure_team']
+
+        - name: Remove ACL
+          ansibleguy.opnsense.haproxy_acl:
+            name: 'old_acl'
+            state: 'absent'
+
+        - name: List all ACLs
+          ansibleguy.opnsense.list:
+          register: haproxy_acls
+
+        - name: Show ACLs
+          ansible.builtin.debug:
+            var: haproxy_acls.data

--- a/docs/source/modules/haproxy_acl.rst
+++ b/docs/source/modules/haproxy_acl.rst
@@ -14,10 +14,6 @@ HAProxy ACL
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_acl.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_action.rst
+++ b/docs/source/modules/haproxy_action.rst
@@ -14,10 +14,6 @@ HAProxy - Action
 
 **TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_action.yml>`_
 
-**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_action.rst
+++ b/docs/source/modules/haproxy_action.rst
@@ -1,0 +1,164 @@
+.. _modules_haproxy_action:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy - Action
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_action.yml>`_
+
+**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Prerequisites
+*************
+
+You need to install and configure HAProxy on the target system.
+
+.. include:: ../_include/haproxy.rst
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+ansibleguy.opnsense.haproxy_action
+***********************************
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","n","Name of the HAProxy action"
+    "description","string","false","\-","desc","Description for the action"
+    "test_type","string","false","if","\-","Test type for the action. One of: 'if', 'unless'"
+    "linked_acls","list","false","\-","acls","**NEW**: List of ACL names to link to this action - supports automatic UUID resolution"
+    "operator","string","false","and","\-","Logical operator for multiple ACLs. One of: 'and', 'or'"
+    "action_type","string","true","\-","type","Type of action to perform. One of: 'use_backend', 'use_server', 'map_use_backend', 'http-request_*', 'http-response_*', 'tcp-request_*', 'tcp-response_*', 'fcgi_*', 'monitor_fail', 'custom'"
+    "use_backend","string","false","\-","backend","**NEW**: Backend name to use (for use_backend action type) - supports automatic UUID resolution"
+    "use_server","list","false","\-","servers","**NEW**: List of server names to use (for use_server action type) - supports automatic UUID resolution"
+    "http_request_auth","string","false","\-","\-","HTTP request authentication config"
+    "http_request_redirect","string","false","\-","\-","HTTP request redirect config"
+    "http_request_lua","string","false","\-","\-","HTTP request Lua script config"
+    "custom_lua","string","false","\-","\-","Custom Lua code"
+    "map_use_backend_file","string","false","\-","\-","Map file for backend selection"
+    "map_use_backend_default","string","false","\-","\-","**NEW**: Default backend name for map-based selection - supports automatic UUID resolution"
+
+.. include:: ../_include/param_basic_en_state.rst
+
+Usage
+*****
+
+This module manages HAProxy actions on OPNsense. Actions define what should be done when certain conditions (defined by ACLs) are met during request processing.
+
+Key features:
+
+- **Automatic UUID Resolution**: All relationship fields accept names and automatically resolve to UUIDs
+- **Name-based Linking**: Users can specify ACL names, backend names, and server names instead of UUIDs
+- **UI Compatibility**: All selections appear correctly in the OPNsense web interface
+- **Multi-select Support**: Lists support multiple items with proper comma-separated format
+- **Flexible Action Types**: Support for HTTP requests/responses, TCP requests/responses, backend routing, and custom actions
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_action'
+
+      tasks:
+        - name: Create HTTPS redirect action with name-based ACL linking
+          ansibleguy.opnsense.haproxy_action:
+            name: 'redirect_to_https'
+            description: 'Redirect HTTP to HTTPS'
+            action_type: 'http-request_redirect'
+            http_request_redirect: 'scheme https'
+            test_type: 'unless'
+            linked_acls: ['ssl_fc', 'is_secure']  # Uses ACL names, not UUIDs
+
+        - name: Route API requests using name-based backend linking
+          ansibleguy.opnsense.haproxy_action:
+            name: 'use_api_backend'
+            description: 'Route API requests to API backend'
+            action_type: 'use_backend'
+            use_backend: 'api_backend'  # Uses backend name, not UUID
+            linked_acls: ['is_api_request', 'valid_token']
+
+        - name: Load balance to specific servers by name
+          ansibleguy.opnsense.haproxy_action:
+            name: 'use_priority_servers'
+            description: 'Route to priority servers'
+            action_type: 'use_server'
+            use_server: ['web01', 'web02']  # Uses server names, not UUIDs
+            linked_acls: ['high_priority_users']
+
+        - name: Deny blocked IPs with multiple ACL conditions
+          ansibleguy.opnsense.haproxy_action:
+            name: 'deny_blocked_ips'
+            description: 'Deny requests from blocked IP ranges'
+            action_type: 'http-request_deny'
+            linked_acls: ['blocked_ips', 'suspicious_patterns']
+            operator: 'or'  # Match any of the linked ACLs
+
+        - name: Map-based backend selection with default
+          ansibleguy.opnsense.haproxy_action:
+            name: 'map_backend_routing'
+            description: 'Route based on domain mapping'
+            action_type: 'map_use_backend'
+            map_use_backend_file: 'domain_backend_map'
+            map_use_backend_default: 'default_backend'  # Uses backend name
+            linked_acls: ['valid_domain']
+
+        - name: Complex authentication action
+          ansibleguy.opnsense.haproxy_action:
+            name: 'require_admin_auth'
+            description: 'Require authentication for admin pages'
+            action_type: 'http-request_auth'
+            http_request_auth: 'realm admin'
+            test_type: 'if'
+            linked_acls: ['admin_path', 'not_authenticated']
+            operator: 'and'
+
+        - name: Custom Lua processing
+          ansibleguy.opnsense.haproxy_action:
+            name: 'custom_processing'
+            description: 'Custom request processing'
+            action_type: 'http-request_lua'
+            http_request_lua: 'process_request'
+            custom_lua: |
+              -- Custom Lua code here
+              core.Debug("Processing custom request")
+            linked_acls: ['needs_processing']
+
+        - name: List all actions
+          ansibleguy.opnsense.list:
+          register: haproxy_actions
+
+        - name: Show actions
+          ansible.builtin.debug:
+            var: haproxy_actions.data

--- a/docs/source/modules/haproxy_backend.rst
+++ b/docs/source/modules/haproxy_backend.rst
@@ -1,0 +1,145 @@
+.. _modules_haproxy_backend:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy Backend
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_backend.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Backend name"
+    "description","string","false","\-","\-","Backend description"
+    "enabled","boolean","false","true","\-","Enable or disable backend"
+    "mode","string","false","http","\-","Backend mode (http, tcp)"
+    "algorithm","string","false","roundrobin","\-","Load balancing algorithm: roundrobin, static-rr, leastconn, first, source, uri, random, rdp-cookie"
+    "source","string","false","\-","\-","Source IP address for backend connections"
+    "health_check_enabled","boolean","false","false","\-","Enable health checks"
+    "health_check","string","false","\-","\-","Health check configuration name"
+    "health_check_interval","string","false","2s","\-","Health check interval (e.g., 2s, 30s, 1m)"
+    "health_check_timeout","string","false","2s","\-","Health check timeout (e.g., 2s, 30s, 1m)"
+    "health_check_retries","integer","false","3","\-","Number of health check retries"
+    "linked_servers","list","false","\-","\-","**NEW**: List of server names to link (automatic UUID resolution)"
+    "linked_actions","list","false","\-","\-","**NEW**: List of action names to link (automatic UUID resolution)"
+    "linked_errorfiles","list","false","\-","\-","**NEW**: List of errorfile names to link (automatic UUID resolution)"
+    "basic_auth_users","list","false","\-","\-","**NEW**: List of user names for authentication (automatic UUID resolution)"
+    "basic_auth_groups","list","false","\-","\-","**NEW**: List of group names for authentication (automatic UUID resolution)"
+    "linked_resolver","string","false","\-","\-","Resolver name for DNS resolution"
+    "http_reuse","string","false","never","\-","HTTP connection reuse: never, safe, aggressive, always"
+    "state","string","false","present","\-","State of the backend (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy backend configurations. Backends define pools of servers that can handle requests from frontends. You can configure load balancing algorithms, health checks, server linking, authentication, error handling, and advanced routing features.
+
+**Key Features:**
+
+* **Automatic UUID Resolution**: All relationship fields (servers, actions, users, groups, etc.) accept names and automatically resolve to UUIDs
+* **Name-based Linking**: Link servers, actions, errorfiles, and authentication resources by name instead of UUID
+* **UI Compatibility**: All selections appear correctly in the OPNsense web interface
+* **Multi-select Support**: Lists support multiple items with proper comma-separated UUID format
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_backend'
+
+      tasks:
+        - name: Create comprehensive backend with all features
+          ansibleguy.opnsense.haproxy_backend:
+            name: 'web_backend'
+            description: 'Main web backend with full configuration'
+            enabled: true
+            mode: 'http'
+            algorithm: 'roundrobin'
+            source: '10.0.1.100'
+            health_check_enabled: true
+            health_check: 'web_health_check'
+            health_check_interval: '30s'
+            health_check_timeout: '5s'
+            health_check_retries: 3
+            linked_servers: ['web1', 'web2', 'web3']
+            linked_actions: ['log_requests', 'add_security_headers']
+            linked_errorfiles: ['custom_404', 'custom_500']
+            basic_auth_users: ['admin', 'operator']
+            basic_auth_groups: ['admins', 'operators']
+            http_reuse: 'safe'
+
+        - name: Create simple HTTP backend with servers
+          ansibleguy.opnsense.haproxy_backend:
+            name: 'api_backend'
+            description: 'API servers backend'
+            mode: 'http'
+            algorithm: 'leastconn'
+            linked_servers: ['api1', 'api2']
+            health_check_enabled: true
+
+        - name: Create TCP backend for databases
+          ansibleguy.opnsense.haproxy_backend:
+            name: 'database_backend'
+            description: 'Database servers backend'
+            mode: 'tcp'
+            algorithm: 'source'
+            linked_servers: ['db_primary', 'db_replica']
+
+        - name: Create backend with authentication
+          ansibleguy.opnsense.haproxy_backend:
+            name: 'secure_backend'
+            description: 'Backend with user authentication'
+            mode: 'http'
+            basic_auth_users: ['secure_user1', 'secure_user2']
+            basic_auth_groups: ['secure_group']
+            linked_errorfiles: ['auth_error']
+
+        - name: Remove backend
+          ansibleguy.opnsense.haproxy_backend:
+            name: 'old_backend'
+            state: 'absent'
+
+        - name: List all backends
+          ansibleguy.opnsense.list:
+          register: haproxy_backends
+
+        - name: Show backends
+          ansible.builtin.debug:
+            var: haproxy_backends.data

--- a/docs/source/modules/haproxy_backend.rst
+++ b/docs/source/modules/haproxy_backend.rst
@@ -14,10 +14,6 @@ HAProxy Backend
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_backend.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_cpu.rst
+++ b/docs/source/modules/haproxy_cpu.rst
@@ -14,10 +14,6 @@ HAProxy - CPU Affinity
 
 **TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_cpu.yml>`_
 
-**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_cpu.rst
+++ b/docs/source/modules/haproxy_cpu.rst
@@ -1,0 +1,76 @@
+.. _modules_haproxy_cpu:
+
+.. include:: ../_include/head.rst
+
+=======================
+HAProxy - CPU Affinity
+=======================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_cpu.yml>`_
+
+**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Prerequisites
+*************
+
+You need to install and configure HAProxy on the target system.
+
+.. include:: ../_include/haproxy.rst
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+ansibleguy.opnsense.haproxy_cpu
+*******************************
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","n","Name of the CPU affinity rule"
+    "thread_id","string","true","\-","\-","Thread ID to bind. Options: 'all', 'odd', 'even', 'x1'-'x63'"
+    "cpu_id","string","true","\-","\-","CPU ID to bind to. Options: 'all', 'odd', 'even', 'x0'-'x63'"
+
+.. include:: ../_include/param_basic_en_state.rst
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - ansibleguy.opnsense.haproxy_cpu:
+        name: 'bind_thread1_cpu0'
+        description: 'Bind HAProxy thread 1 to CPU 0'
+        thread_id: 'x1'
+        cpu_id: 'x0'
+
+    - ansibleguy.opnsense.haproxy_cpu:
+        name: 'bind_odd_threads'
+        description: 'Bind odd threads to odd CPUs'
+        thread_id: 'odd'
+        cpu_id: 'odd'
+
+    - ansibleguy.opnsense.haproxy_cpu:
+        name: 'bind_all_threads'
+        description: 'Bind all threads to all CPUs'
+        thread_id: 'all'
+        cpu_id: 'all'

--- a/docs/source/modules/haproxy_errorfile.rst
+++ b/docs/source/modules/haproxy_errorfile.rst
@@ -14,10 +14,6 @@ HAProxy Error File
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_errorfile.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_errorfile.rst
+++ b/docs/source/modules/haproxy_errorfile.rst
@@ -1,0 +1,141 @@
+.. _modules_haproxy_errorfile:
+
+.. include:: ../_include/head.rst
+
+==================
+HAProxy Error File
+==================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_errorfile.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Error file name"
+    "description","string","false","\-","\-","Error file description"
+    "enabled","boolean","false","true","\-","Enable or disable error file"
+    "code","string","true","\-","\-","HTTP error code (200, 400, 403, 405, 408, 429, 500, 502, 503, 504)"
+    "content","string","true","\-","\-","Error file content (HTML)"
+    "state","string","false","present","\-","State of the error file (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy custom error files. Error files allow you to customize the error pages that HAProxy serves when specific HTTP errors occur, improving user experience and providing consistent branding.
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_errorfile'
+
+      tasks:
+        - name: Create custom 404 error page
+          ansibleguy.opnsense.haproxy_errorfile:
+            name: 'custom_404'
+            description: 'Custom 404 error page'
+            enabled: true
+            code: '404'
+            content: |
+              HTTP/1.1 404 Not Found
+              Content-Type: text/html
+              Cache-Control: no-cache
+              Connection: close
+              
+              <!DOCTYPE html>
+              <html>
+              <head>
+                  <title>Page Not Found</title>
+                  <style>
+                      body { font-family: Arial, sans-serif; text-align: center; margin-top: 50px; }
+                      h1 { color: #e74c3c; }
+                  </style>
+              </head>
+              <body>
+                  <h1>404 - Page Not Found</h1>
+                  <p>The page you are looking for could not be found.</p>
+              </body>
+              </html>
+
+        - name: Create custom 503 maintenance page
+          ansibleguy.opnsense.haproxy_errorfile:
+            name: 'maintenance_503'
+            description: 'Maintenance mode page'
+            enabled: true
+            code: '503'
+            content: |
+              HTTP/1.1 503 Service Unavailable
+              Content-Type: text/html
+              Cache-Control: no-cache
+              Connection: close
+              
+              <!DOCTYPE html>
+              <html>
+              <head>
+                  <title>Maintenance Mode</title>
+              </head>
+              <body>
+                  <h1>Service Temporarily Unavailable</h1>
+                  <p>We are currently performing maintenance. Please try again later.</p>
+              </body>
+              </html>
+
+        - name: Create custom 500 error page
+          ansibleguy.opnsense.haproxy_errorfile:
+            name: 'custom_500'
+            description: 'Internal server error page'
+            enabled: true
+            code: '500'
+            content: |
+              HTTP/1.1 500 Internal Server Error
+              Content-Type: text/html
+              
+              <html><body><h1>Internal Server Error</h1></body></html>
+
+        - name: Remove error file
+          ansibleguy.opnsense.haproxy_errorfile:
+            name: 'old_errorfile'
+            state: 'absent'
+
+        - name: List all error files
+          ansibleguy.opnsense.list:
+          register: haproxy_errorfiles
+
+        - name: Show error files
+          ansible.builtin.debug:
+            var: haproxy_errorfiles.data

--- a/docs/source/modules/haproxy_exporter.rst
+++ b/docs/source/modules/haproxy_exporter.rst
@@ -1,0 +1,179 @@
+.. _modules_haproxy_exporter:
+
+.. include:: ../_include/head.rst
+
+===================
+HAProxy Exporter
+===================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_exporter.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "export_type","string","true","\-","\-","Type of export operation (config, diff, download)"
+    "download_type","string","false","\-","\-","Specific download type when export_type is 'download'"
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module exports HAProxy configuration and related data from OPNsense. It provides various export formats for configuration backup, analysis, and integration with external tools.
+
+Available export types:
+
+- **config**: Export the current HAProxy configuration in native format
+- **diff**: Export configuration differences for change tracking
+- **download**: Download specific HAProxy data files and reports
+
+Key features:
+
+- **Configuration backup**: Export complete HAProxy configurations
+- **Change tracking**: Generate configuration diffs for auditing
+- **Data extraction**: Download specific HAProxy data files
+- **Integration support**: Provide data for external monitoring and management tools
+- **Read-only operations**: Safe export without configuration changes
+- **Multiple formats**: Support various export formats and data types
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Export HAProxy configuration
+          ansibleguy.opnsense.haproxy_exporter:
+            export_type: config
+          register: haproxy_config
+
+        - name: Save configuration to file
+          ansible.builtin.copy:
+            content: "{{ haproxy_config.result.config }}"
+            dest: "/backup/haproxy_{{ ansible_date_time.date }}.cfg"
+          when: haproxy_config.result.config is defined
+
+        - name: Export configuration differences
+          ansibleguy.opnsense.haproxy_exporter:
+            export_type: diff
+          register: config_diff
+
+        - name: Display configuration changes
+          ansible.builtin.debug:
+            var: config_diff.result
+          when: config_diff.result.changes is defined
+
+        - name: Download HAProxy data files
+          ansibleguy.opnsense.haproxy_exporter:
+            export_type: download
+            download_type: "statistics"
+          register: stats_download
+
+        - name: Backup configuration with timestamp
+          block:
+            - name: Export current config
+              ansibleguy.opnsense.haproxy_exporter:
+                export_type: config
+              register: current_config
+
+            - name: Create backup directory
+              ansible.builtin.file:
+                path: "/backup/haproxy/{{ ansible_date_time.date }}"
+                state: directory
+
+            - name: Save configuration backup
+              ansible.builtin.copy:
+                content: "{{ current_config.result.config }}"
+                dest: "/backup/haproxy/{{ ansible_date_time.date }}/haproxy.cfg"
+
+        - name: Monitor configuration changes
+          block:
+            - name: Check for configuration diff
+              ansibleguy.opnsense.haproxy_exporter:
+                export_type: diff
+              register: daily_diff
+
+            - name: Alert on configuration changes
+              ansible.builtin.mail:
+                to: admin@example.com
+                subject: "HAProxy Configuration Changes Detected"
+                body: |
+                  Configuration changes detected on {{ inventory_hostname }}:
+                  {{ daily_diff.result | to_nice_json }}
+              when: 
+                - daily_diff.result.changes is defined
+                - daily_diff.result.changes | length > 0
+
+        - name: Generate configuration report
+          block:
+            - name: Export configuration
+              ansibleguy.opnsense.haproxy_exporter:
+                export_type: config
+              register: config_export
+
+            - name: Download additional data
+              ansibleguy.opnsense.haproxy_exporter:
+                export_type: download
+                download_type: "{{ item }}"
+              register: downloads
+              loop:
+                - "statistics"
+                - "logs"
+                - "certificates"
+
+            - name: Generate comprehensive report
+              ansible.builtin.template:
+                src: haproxy_report.j2
+                dest: "/reports/haproxy_{{ ansible_date_time.date }}.html"
+              vars:
+                config: "{{ config_export.result }}"
+                downloads: "{{ downloads.results }}"
+
+        - name: Configuration validation workflow
+          block:
+            - name: Export current configuration
+              ansibleguy.opnsense.haproxy_exporter:
+                export_type: config
+              register: before_config
+
+            - name: Apply configuration changes
+              # ... make configuration changes ...
+
+            - name: Export updated configuration
+              ansibleguy.opnsense.haproxy_exporter:
+                export_type: config
+              register: after_config
+
+            - name: Compare configurations
+              ansible.builtin.debug:
+                msg: "Configuration size changed from {{ before_config.result.config | length }} to {{ after_config.result.config | length }} characters"

--- a/docs/source/modules/haproxy_exporter.rst
+++ b/docs/source/modules/haproxy_exporter.rst
@@ -14,10 +14,6 @@ HAProxy Exporter
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_exporter.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_fcgi.rst
+++ b/docs/source/modules/haproxy_fcgi.rst
@@ -14,10 +14,6 @@ HAProxy - FCGI
 
 **TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_fcgi.yml>`_
 
-**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_fcgi.rst
+++ b/docs/source/modules/haproxy_fcgi.rst
@@ -1,0 +1,73 @@
+.. _modules_haproxy_fcgi:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy - FCGI
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_fcgi.yml>`_
+
+**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Prerequisites
+************
+
+You need to install and configure HAProxy on the target system.
+
+.. include:: ../_include/haproxy.rst
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+ansibleguy.opnsense.haproxy_fcgi
+********************************
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","n","Name of the FCGI app"
+    "description","string","false","\-","desc","Description for the FCGI app"
+    "docroot","string","false","\-","\-","Document root path for the FCGI application"
+    "index","string","false","index.php","\-","Default index file"
+    "linked_actions","list","false","\-","actions","List of action names to link to this FCGI app"
+
+.. include:: ../_include/param_basic_en_state.rst
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - ansibleguy.opnsense.haproxy_fcgi:
+        name: 'php_app'
+        description: 'PHP FastCGI application'
+        docroot: '/var/www/html'
+        index: 'index.php'
+
+    - ansibleguy.opnsense.haproxy_fcgi:
+        name: 'wordpress'
+        description: 'WordPress FCGI configuration'
+        docroot: '/var/www/wordpress'
+        index: 'index.php'
+        linked_actions: ['wordpress_actions']

--- a/docs/source/modules/haproxy_frontend.rst
+++ b/docs/source/modules/haproxy_frontend.rst
@@ -1,0 +1,162 @@
+.. _modules_haproxy_frontend:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy Frontend
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_frontend.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Frontend name (unique identifier)"
+    "description","string","false","\-","\-","Frontend description"
+    "enabled","boolean","false","true","\-","Enable or disable frontend"
+    "bind_address","string","true","\-","\-","IP address to bind to"
+    "bind_port","integer","true","\-","\-","Port to bind to (1-65535)"
+    "ssl_enabled","boolean","false","false","\-","Enable SSL/TLS encryption"
+    "ssl_certificates","list","false","\-","\-","List of SSL certificate names"
+    "default_backend","string","false","\-","\-","**NEW**: Default backend name (automatic UUID resolution)"
+    "linked_actions","list","false","\-","\-","**NEW**: List of action names to apply (automatic UUID resolution)"
+    "linked_errorfiles","list","false","\-","\-","**NEW**: List of errorfile names for custom errors (automatic UUID resolution)"
+    "basic_auth_users","list","false","\-","\-","**NEW**: List of user names for authentication (automatic UUID resolution)"
+    "basic_auth_groups","list","false","\-","\-","**NEW**: List of group names for authentication (automatic UUID resolution)"
+    "mode","string","false","http","\-","Frontend mode (http, tcp)"
+    "max_connections","integer","false","\-","\-","Maximum number of concurrent connections"
+    "log_enabled","boolean","false","false","\-","Enable logging for this frontend"
+    "advanced_options","string","false","\-","\-","Advanced HAProxy configuration options"
+    "state","string","false","present","\-","State of the frontend (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy frontend configurations on OPNsense. Frontends define the entry points for client connections, handling SSL termination, protocol selection, and routing to appropriate backends.
+
+**Key Features:**
+
+* **Network binding**: Configure IP addresses and ports for client connections
+* **SSL/TLS termination**: Handle encrypted connections with certificate management  
+* **Protocol handling**: Support for HTTP and TCP modes
+* **Automatic UUID Resolution**: All relationship fields (backends, actions, users, groups, etc.) accept names and automatically resolve to UUIDs
+* **Name-based Linking**: Link backends, actions, errorfiles, and authentication resources by name instead of UUID
+* **UI Compatibility**: All selections appear correctly in the OPNsense web interface
+* **Multi-select Support**: Lists support multiple items with proper comma-separated UUID format
+* **Connection limits**: Control concurrent connection limits per frontend
+* **Logging integration**: Optional per-frontend logging configuration
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_frontend'
+
+      tasks:
+        - name: Create comprehensive frontend with all features
+          ansibleguy.opnsense.haproxy_frontend:
+            name: "web_frontend"
+            description: "Main web frontend with full configuration"
+            enabled: true
+            bind_address: "10.0.0.100"
+            bind_port: 443
+            ssl_enabled: true
+            ssl_certificates: ['web-cert', 'backup-cert']
+            mode: "http"
+            default_backend: "web_backend"
+            linked_actions: ['log_requests', 'security_headers', 'rate_limit']
+            linked_errorfiles: ['custom_404', 'custom_500', 'maintenance']
+            basic_auth_users: ['admin', 'support']
+            basic_auth_groups: ['admins', 'operators']
+            max_connections: 1000
+            log_enabled: true
+
+        - name: Create simple HTTP frontend
+          ansibleguy.opnsense.haproxy_frontend:
+            name: "api_frontend"
+            description: "API frontend"
+            bind_address: "0.0.0.0"
+            bind_port: 80
+            mode: "http"
+            default_backend: "api_backend"
+            linked_actions: ['cors_headers']
+
+        - name: Create HTTPS frontend with authentication
+          ansibleguy.opnsense.haproxy_frontend:
+            name: "secure_frontend"
+            description: "Secure HTTPS frontend with auth"
+            bind_address: "10.0.0.200"
+            bind_port: 443
+            ssl_enabled: true
+            ssl_certificates: ['secure-cert']
+            mode: "http"
+            default_backend: "secure_backend"
+            basic_auth_users: ['admin_user']
+            basic_auth_groups: ['admin_group']
+            linked_errorfiles: ['auth_required']
+
+        - name: Create TCP frontend for database
+          ansibleguy.opnsense.haproxy_frontend:
+            name: "db_frontend"
+            description: "Database TCP frontend"
+            bind_address: "10.0.1.10"
+            bind_port: 5432
+            mode: "tcp"
+            default_backend: "database_backend"
+
+        - name: Create frontend with custom bind addresses
+          ansibleguy.opnsense.haproxy_frontend:
+            name: "multi_bind_frontend"
+            description: "Frontend with different bind examples"
+            bind_address: "*"        # All interfaces
+            bind_port: 8080
+            mode: "http"
+            default_backend: "web_backend"
+
+        - name: Remove old frontend
+          ansibleguy.opnsense.haproxy_frontend:
+            name: "old_frontend"
+            state: absent
+
+        - name: List all frontends
+          ansibleguy.opnsense.list:
+          register: haproxy_frontends
+
+        - name: Show frontends
+          ansible.builtin.debug:
+            var: haproxy_frontends.data

--- a/docs/source/modules/haproxy_frontend.rst
+++ b/docs/source/modules/haproxy_frontend.rst
@@ -14,10 +14,6 @@ HAProxy Frontend
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_frontend.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_general.rst
+++ b/docs/source/modules/haproxy_general.rst
@@ -1,0 +1,191 @@
+.. _modules_haproxy_general:
+
+.. include:: ../_include/head.rst
+
+=====================
+HAProxy General
+=====================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_general.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "enabled","boolean","false","false","\-","Enable or disable HAProxy service"
+    "graceful_stop","boolean","false","false","\-","Enable graceful stop"
+    "hard_stop_after","string","false","60s","\-","Hard stop after timeout"
+    "close_spread_time","string","false","\-","\-","Close spread time"
+    "seamless_reload","boolean","false","false","\-","Enable seamless reload"
+    "show_intro","boolean","false","true","\-","Show introduction page"
+    "store_ocsp","boolean","false","false","\-","Store OCSP responses"
+    "tuning_max_connections","integer","false","\-","\-","Maximum number of connections (tuning)"
+    "tuning_nbthread","integer","false","1","\-","Number of threads"
+    "tuning_resolvers_prefer","string","false","ipv4","\-","DNS resolver preference (ipv4/ipv6)"
+    "tuning_ssl_server_verify","string","false","ignore","\-","SSL server verification (ignore/required)"
+    "tuning_root","boolean","false","false","\-","Run as root user"
+    "tuning_max_dh_size","integer","false","2048","\-","Maximum DH key size (1024-16384)"
+    "tuning_buffer_size","integer","false","16384","\-","Buffer size (1024-1048576)"
+    "tuning_spread_checks","integer","false","2","\-","Spread health checks (0-50)"
+    "tuning_bogus_proxy_enabled","boolean","false","false","\-","Enable bogus proxy protocol"
+    "tuning_lua_max_mem","integer","false","0","\-","Maximum Lua memory (0-1024 MB)"
+    "tuning_custom_options","string","false","\-","\-","Custom tuning options"
+    "tuning_ocsp_update_enabled","boolean","false","false","\-","Enable OCSP auto-updates"
+    "tuning_ocsp_update_min_delay","integer","false","300","\-","OCSP min delay (1-86400s)"
+    "tuning_ocsp_update_max_delay","integer","false","3600","\-","OCSP max delay (1-86400s)"
+    "tuning_ssl_defaults_enabled","boolean","false","false","\-","Enable SSL defaults"
+    "tuning_ssl_bind_options","list","false","\-","\-","SSL bind options"
+    "tuning_ssl_min_version","string","false","TLSv1.2","\-","Minimum SSL/TLS version"
+    "tuning_ssl_max_version","string","false","\-","\-","Maximum SSL/TLS version"
+    "peers_enabled","boolean","false","false","\-","Enable peer synchronization"
+    "peers_name1","string","false","\-","\-","First peer name"
+    "peers_listen1","string","false","\-","\-","First peer listen address"
+    "peers_port1","integer","false","1024","\-","First peer port (1-65535)"
+    "peers_name2","string","false","\-","\-","Second peer name"
+    "peers_listen2","string","false","\-","\-","Second peer listen address"
+    "peers_port2","integer","false","1024","\-","Second peer port (1-65535)"
+    "defaults_max_connections","integer","false","\-","\-","Default max connections per process"
+    "defaults_max_connections_servers","integer","false","\-","\-","Default max connections to servers"
+    "defaults_timeout_client","string","false","30s","\-","Default client timeout"
+    "defaults_timeout_connect","string","false","30s","\-","Default connection timeout"
+    "defaults_timeout_check","string","false","\-","\-","Default health check timeout"
+    "defaults_timeout_server","string","false","30s","\-","Default server timeout"
+    "defaults_retries","integer","false","3","\-","Default number of retries (0-100)"
+    "defaults_redispatch","string","false","x-1","\-","Redispatch configuration"
+    "defaults_init_addr","list","false","[last,libc]","\-","Default server address init methods"
+    "defaults_custom_options","string","false","\-","\-","Custom default options"
+    "logging_host","string","false","127.0.0.1","\-","Syslog server hostname/IP"
+    "logging_facility","string","false","local0","\-","Syslog facility"
+    "logging_level","string","false","info","\-","Syslog level"
+    "logging_length","integer","false","\-","\-","Max syslog message length (64-65535)"
+    "stats_enabled","boolean","false","false","\-","Enable HAProxy statistics"
+    "stats_port","integer","false","8822","\-","Statistics port (1024-65535)"
+    "stats_remote_enabled","boolean","false","false","\-","Enable remote statistics access"
+    "stats_remote_bind","list","false","\-","\-","Remote bind addresses for stats"
+    "stats_auth_enabled","boolean","false","false","\-","Enable statistics authentication"
+    "stats_users","list","false","\-","\-","Statistics users (user:password format)"
+    "stats_custom_options","string","false","\-","\-","Custom statistics options"
+    "stats_prometheus_enabled","boolean","false","false","\-","Enable Prometheus metrics"
+    "stats_prometheus_bind","list","false","[*:8404]","\-","Prometheus bind addresses"
+    "stats_prometheus_path","string","false","/metrics","\-","Prometheus metrics path"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module configures the comprehensive HAProxy general settings on OPNsense. It provides complete control over:
+
+- **Basic service control**: Enable/disable, graceful shutdown, seamless reloads
+- **Performance tuning**: Connection limits, threading, buffer sizes, SSL optimization
+- **High availability**: Peer synchronization for load balancer clustering  
+- **Logging**: Syslog integration with facility and level control
+- **Statistics & monitoring**: Built-in stats interface and Prometheus metrics
+- **SSL/TLS security**: Version control, cipher management, OCSP handling
+- **Default behaviors**: Timeouts, retries, connection handling
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_general'
+
+      tasks:
+        - name: Basic HAProxy configuration
+          ansibleguy.opnsense.haproxy_general:
+            enabled: true
+            graceful_stop: true
+            hard_stop_after: '60s'
+            seamless_reload: true
+            show_intro: false
+
+        - name: High-performance configuration
+          ansibleguy.opnsense.haproxy_general:
+            enabled: true
+            tuning_max_connections: 10000
+            tuning_nbthread: 4
+            tuning_buffer_size: 32768
+            tuning_spread_checks: 5
+            defaults_timeout_client: '60s'
+            defaults_timeout_server: '60s'
+            defaults_retries: 5
+
+        - name: SSL/TLS security hardening
+          ansibleguy.opnsense.haproxy_general:
+            enabled: true
+            tuning_ssl_min_version: 'TLSv1.2'
+            tuning_ssl_max_version: 'TLSv1.3'
+            tuning_max_dh_size: 4096
+            tuning_ssl_defaults_enabled: true
+            tuning_ocsp_update_enabled: true
+
+        - name: Enable statistics and monitoring
+          ansibleguy.opnsense.haproxy_general:
+            enabled: true
+            stats_enabled: true
+            stats_port: 8080
+            stats_auth_enabled: true
+            stats_users:
+              - "admin:secret123"
+            stats_prometheus_enabled: true
+            stats_prometheus_bind:
+              - "*:9090"
+
+        - name: Configure high availability with peers
+          ansibleguy.opnsense.haproxy_general:
+            enabled: true
+            peers_enabled: true
+            peers_name1: "node1"
+            peers_listen1: "10.0.1.10"
+            peers_port1: 1024
+            peers_name2: "node2"
+            peers_listen2: "10.0.1.11"
+            peers_port2: 1024
+
+        - name: Advanced logging configuration
+          ansibleguy.opnsense.haproxy_general:
+            enabled: true
+            logging_host: "syslog.example.com"
+            logging_facility: "local1"
+            logging_level: "info"
+            logging_length: 1024
+
+        - name: List HAProxy configuration
+          ansibleguy.opnsense.list:
+          register: haproxy_config
+
+        - name: Show configuration
+          ansible.builtin.debug:
+            var: haproxy_config.data

--- a/docs/source/modules/haproxy_general.rst
+++ b/docs/source/modules/haproxy_general.rst
@@ -14,10 +14,6 @@ HAProxy General
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_general.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_group.rst
+++ b/docs/source/modules/haproxy_group.rst
@@ -1,0 +1,135 @@
+.. _modules_haproxy_group:
+
+.. include:: ../_include/head.rst
+
+=============
+HAProxy Group
+=============
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_group.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Group name (unique identifier)"
+    "description","string","false","\-","\-","Group description"
+    "enabled","boolean","false","true","\-","Enable or disable group"
+    "members","list","false","\-","\-","**NEW**: List of user names as group members - supports automatic UUID resolution"
+    "add_userlist","boolean","false","false","\-","Add to userlist for authentication purposes"
+
+Usage
+*****
+
+This module manages HAProxy user groups on OPNsense for authentication and authorization purposes. Groups organize users into logical collections that can be referenced in ACLs and authentication rules.
+
+Key features:
+
+- **Automatic UUID Resolution**: All relationship fields accept names and automatically resolve to UUIDs
+- **Name-based Linking**: Users can specify user names instead of UUIDs for group membership
+- **UI Compatibility**: All selections appear correctly in the OPNsense web interface
+- **Multi-select Support**: Lists support multiple users with proper comma-separated format
+- **Authentication integration**: Groups can be used in HTTP authentication ACLs
+- **Userlist management**: Control whether groups appear in HAProxy userlists
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_group'
+
+      tasks:
+        - name: Create admin group with name-based user linking
+          ansibleguy.opnsense.haproxy_group:
+            name: 'administrators'
+            description: 'System administrators group'
+            enabled: true
+            members: ['admin', 'root', 'sysadmin']  # Uses user names, not UUIDs
+            add_userlist: true
+
+        - name: Create development team group
+          ansibleguy.opnsense.haproxy_group:
+            name: 'developers'
+            description: 'Development team members'
+            enabled: true
+            members: ['alice', 'bob', 'charlie', 'diana']
+            add_userlist: true
+
+        - name: Create security team group
+          ansibleguy.opnsense.haproxy_group:
+            name: 'security_team'
+            description: 'Security and compliance team'
+            enabled: true
+            members: ['security_admin', 'auditor']
+            add_userlist: true
+
+        - name: Create read-only group
+          ansibleguy.opnsense.haproxy_group:
+            name: 'readonly_users'
+            description: 'Users with read-only access'
+            enabled: true
+            members: ['viewer1', 'viewer2', 'guest']
+            add_userlist: false  # Not added to userlist for auth
+
+        - name: Create empty group for future use
+          ansibleguy.opnsense.haproxy_group:
+            name: 'future_group'
+            description: 'Group reserved for future users'
+            enabled: false
+            members: []
+
+        - name: Update existing group membership
+          ansibleguy.opnsense.haproxy_group:
+            name: 'administrators'
+            members: ['admin', 'root', 'sysadmin', 'new_admin']  # Add new member
+
+        - name: Disable group temporarily
+          ansibleguy.opnsense.haproxy_group:
+            name: 'maintenance_group'
+            enabled: false
+
+        - name: Remove old group
+          ansibleguy.opnsense.haproxy_group:
+            name: 'deprecated_group'
+            state: absent
+
+        - name: List all groups
+          ansibleguy.opnsense.list:
+          register: haproxy_groups
+
+        - name: Show groups
+          ansible.builtin.debug:
+            var: haproxy_groups.data

--- a/docs/source/modules/haproxy_group.rst
+++ b/docs/source/modules/haproxy_group.rst
@@ -14,10 +14,6 @@ HAProxy Group
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_group.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_healthcheck.rst
+++ b/docs/source/modules/haproxy_healthcheck.rst
@@ -1,0 +1,73 @@
+.. _modules_haproxy_healthcheck:
+
+.. include:: ../_include/head.rst
+
+====================
+HAProxy Health Check
+====================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_healthcheck.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Health check name"
+    "description","string","false","\-","\-","Health check description"
+    "enabled","boolean","false","true","\-","Enable or disable health check"
+    "type","string","true","\-","\-","Health check type"
+    "interval","string","false","\-","\-","Check interval (e.g. 5s, 30s)"
+    "ssl","string","false","\-","\-","SSL settings"
+    "ssl_sni","string","false","\-","\-","SSL SNI hostname"
+    "state","string","false","present","\-","State of the health check (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy health checks for monitoring server availability.
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Create HTTP health check
+          ansibleguy.opnsense.haproxy_healthcheck:
+            name: 'web_health'
+            description: 'Web server health check'
+            enabled: true
+            type: 'http'
+            interval: '5s'

--- a/docs/source/modules/haproxy_healthcheck.rst
+++ b/docs/source/modules/haproxy_healthcheck.rst
@@ -14,10 +14,6 @@ HAProxy Health Check
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_healthcheck.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_lua.rst
+++ b/docs/source/modules/haproxy_lua.rst
@@ -14,10 +14,6 @@ HAProxy - Lua
 
 **TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_lua.yml>`_
 
-**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_lua.rst
+++ b/docs/source/modules/haproxy_lua.rst
@@ -1,0 +1,86 @@
+.. _modules_haproxy_lua:
+
+.. include:: ../_include/head.rst
+
+===============
+HAProxy - Lua
+===============
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/ansibleguy/collection_opnsense/blob/latest/tests/haproxy_lua.yml>`_
+
+**API Docs**: `Core - HAProxy <https://docs.opnsense.org/development/api/core/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Prerequisites
+*************
+
+You need to install and configure HAProxy on the target system.
+
+.. include:: ../_include/haproxy.rst
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+ansibleguy.opnsense.haproxy_lua
+*******************************
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","n","Name of the Lua script"
+    "description","string","false","\-","desc","Description for the Lua script"
+    "preload","boolean","false","true","\-","Whether to preload the Lua script"
+    "filename_scheme","string","false","id","\-","Filename scheme. One of: 'id', 'name'"
+    "content","string","true","\-","\-","Lua script content"
+
+.. include:: ../_include/param_basic_en_state.rst
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - ansibleguy.opnsense.haproxy_lua:
+        name: 'custom_auth'
+        description: 'Custom authentication logic'
+        preload: true
+        filename_scheme: 'name'
+        content: |
+          function authenticate(txn)
+              local auth_header = txn.http:req_get_headers()["authorization"]
+              if auth_header and auth_header[0] then
+                  -- Custom authentication logic here
+                  return true
+              end
+              return false
+          end
+
+    - ansibleguy.opnsense.haproxy_lua:
+        name: 'request_logger'
+        description: 'Log detailed request information'
+        content: |
+          function log_request(txn)
+              local method = txn.http:req_get_method()
+              local path = txn.http:req_get_path()
+              local ip = txn.f:src()
+              core.log(core.info, string.format("Request: %s %s from %s", method, path, ip))
+          end

--- a/docs/source/modules/haproxy_mailer.rst
+++ b/docs/source/modules/haproxy_mailer.rst
@@ -14,10 +14,6 @@ HAProxy Mailer
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_mailer.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_mailer.rst
+++ b/docs/source/modules/haproxy_mailer.rst
@@ -1,0 +1,73 @@
+.. _modules_haproxy_mailer:
+
+.. include:: ../_include/head.rst
+
+==============
+HAProxy Mailer
+==============
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_mailer.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Mailer name"
+    "description","string","false","\-","\-","Mailer description"
+    "enabled","boolean","false","true","\-","Enable or disable mailer"
+    "mailservers","list","true","\-","\-","List of mail servers"
+    "sender","string","true","\-","\-","Sender email address"
+    "recipient","string","true","\-","\-","Recipient email address"
+    "state","string","false","present","\-","State of the mailer (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy mailer configurations for email notifications.
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Create mailer configuration
+          ansibleguy.opnsense.haproxy_mailer:
+            name: 'alerts'
+            description: 'Alert mailer'
+            enabled: true
+            mailservers: ['smtp.example.com:587']
+            sender: 'haproxy@example.com'
+            recipient: 'admin@example.com'

--- a/docs/source/modules/haproxy_maintenance.rst
+++ b/docs/source/modules/haproxy_maintenance.rst
@@ -1,0 +1,174 @@
+.. _modules_haproxy_maintenance:
+
+.. include:: ../_include/head.rst
+
+======================
+HAProxy Maintenance
+======================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_maintenance.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "action","string","true","\-","\-","Maintenance action to perform"
+    "server","string","false","\-","\-","Server identifier (backend/server format)"
+    "state","string","false","\-","\-","Server state for server_state operations (ready, drain, maint)"
+    "weight","integer","false","\-","\-","Server weight for server_weight operations (0-256)"
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module performs various HAProxy maintenance operations on OPNsense. It provides runtime control over server states, weights, and certificate management without requiring configuration reloads.
+
+Available maintenance actions:
+
+- **Server state management**: Control server operational states (ready, drain, maintenance)
+- **Weight management**: Dynamically adjust server weights for load balancing
+- **Certificate operations**: Manage SSL certificates and synchronization
+- **Server discovery**: Search and inspect configured servers
+- **Bulk operations**: Perform actions on multiple servers simultaneously
+
+Key features:
+
+- **Runtime operations**: Make changes without HAProxy service restarts
+- **Server state control**: Enable maintenance mode or graceful drainage
+- **Dynamic weight adjustment**: Balance traffic loads in real-time
+- **Certificate management**: Sync and update SSL certificates
+- **Bulk operations**: Efficiently manage multiple servers
+- **Safe operations**: Non-destructive maintenance commands
+
+Action Types
+************
+
+Server State Actions:
+- ``server_state``: Change individual server state
+- ``server_state_bulk``: Change multiple server states
+
+Weight Management:
+- ``server_weight``: Adjust individual server weight
+- ``server_weight_bulk``: Adjust multiple server weights
+
+Certificate Management:
+- ``cert_sync``: Synchronize certificates
+- ``cert_sync_bulk``: Bulk certificate synchronization
+- ``cert_actions``: Perform certificate actions
+- ``cert_diff``: Check certificate differences
+- ``search_certificate_diff``: Search for certificate changes
+
+Information Gathering:
+- ``get``: Get maintenance information
+- ``search_server``: Search for servers
+- ``fetch_cron_integration``: Get cron integration data
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Get current maintenance information
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: get
+          register: maintenance_info
+
+        - name: Search for all servers
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: search_server
+          register: all_servers
+
+        - name: Display found servers
+          ansible.builtin.debug:
+            var: all_servers.result
+
+        - name: Put server into maintenance mode
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: server_state
+            server: "web_backend/web01"
+            state: maint
+
+        - name: Drain server gracefully
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: server_state
+            server: "api_backend/api01"
+            state: drain
+
+        - name: Bring server back online
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: server_state
+            server: "web_backend/web01"
+            state: ready
+
+        - name: Reduce server weight during maintenance window
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: server_weight
+            server: "web_backend/web02"
+            weight: 50
+
+        - name: Restore normal server weight
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: server_weight
+            server: "web_backend/web02"
+            weight: 100
+
+        - name: Synchronize SSL certificates
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: cert_sync
+
+        - name: Check for certificate differences
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: cert_diff
+          register: cert_changes
+
+        - name: Rolling maintenance example
+          block:
+            - name: Get all servers in backend
+              ansibleguy.opnsense.haproxy_maintenance:
+                action: search_server
+              register: servers
+
+            - name: Perform rolling maintenance
+              include_tasks: server_maintenance.yml
+              loop: "{{ servers.result.servers | default([]) }}"
+              loop_control:
+                loop_var: server_item
+              when: "'web_backend' in server_item"
+
+        - name: Emergency server shutdown
+          ansibleguy.opnsense.haproxy_maintenance:
+            action: server_state
+            server: "{{ emergency_server }}"
+            state: maint
+          when: emergency_shutdown | default(false)

--- a/docs/source/modules/haproxy_maintenance.rst
+++ b/docs/source/modules/haproxy_maintenance.rst
@@ -14,10 +14,6 @@ HAProxy Maintenance
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_maintenance.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_mapfile.rst
+++ b/docs/source/modules/haproxy_mapfile.rst
@@ -1,0 +1,72 @@
+.. _modules_haproxy_mapfile:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy Map File
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_mapfile.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Map file name"
+    "description","string","false","\-","\-","Map file description"
+    "enabled","boolean","false","true","\-","Enable or disable map file"
+    "content","string","true","\-","\-","Map file content"
+    "state","string","false","present","\-","State of the map file (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy map files for dynamic URL rewriting and routing.
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Create URL rewrite map
+          ansibleguy.opnsense.haproxy_mapfile:
+            name: 'url_rewrites'
+            description: 'URL rewrite mappings'
+            enabled: true
+            content: |
+              /old-path /new-path
+              /legacy /modern
+              /api/v1 /api/v2

--- a/docs/source/modules/haproxy_mapfile.rst
+++ b/docs/source/modules/haproxy_mapfile.rst
@@ -14,10 +14,6 @@ HAProxy Map File
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_mapfile.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_resolver.rst
+++ b/docs/source/modules/haproxy_resolver.rst
@@ -1,0 +1,74 @@
+.. _modules_haproxy_resolver:
+
+.. include:: ../_include/head.rst
+
+=================
+HAProxy Resolver
+=================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_resolver.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Resolver name"
+    "description","string","false","\-","\-","Resolver description"
+    "enabled","boolean","false","true","\-","Enable or disable resolver"
+    "nameservers","list","false","\-","\-","List of nameservers"
+    "parse_resolv_conf","boolean","false","false","\-","Parse /etc/resolv.conf"
+    "resolve_retries","integer","false","\-","\-","Number of resolve retries"
+    "timeout_resolve","string","false","\-","\-","Resolve timeout (e.g. 5s)"
+    "state","string","false","present","\-","State of the resolver (present, absent)"
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module manages HAProxy DNS resolvers for dynamic server resolution.
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Create DNS resolver
+          ansibleguy.opnsense.haproxy_resolver:
+            name: 'internal_dns'
+            description: 'Internal DNS resolver'
+            enabled: true
+            nameservers: ['192.168.1.1:53', '192.168.1.2:53']
+            resolve_retries: 3
+            timeout_resolve: '5s'

--- a/docs/source/modules/haproxy_resolver.rst
+++ b/docs/source/modules/haproxy_resolver.rst
@@ -14,10 +14,6 @@ HAProxy Resolver
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_resolver.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_server.rst
+++ b/docs/source/modules/haproxy_server.rst
@@ -1,0 +1,172 @@
+.. _modules_haproxy_server:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy Server
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_server.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","Server name (unique identifier)"
+    "description","string","false","\-","\-","Server description"
+    "enabled","boolean","false","true","\-","Enable or disable the server"
+    "address","string","true","\-","\-","Server IP address or hostname"
+    "port","integer","true","\-","\-","Server port (1-65535)"
+    "ssl","boolean","false","false","\-","Use SSL for backend connection"
+    "ssl_ca","string","false","\-","\-","CA certificate UUID for SSL verification"
+    "weight","integer","false","1","\-","Server weight for load balancing (0-256)"
+    "check_interval","string","false","2s","\-","Health check interval (format: number + optional suffix: us/ms/s/m/h/d)"
+    "check_down_interval","string","false","\-","\-","Health check interval when server is down (format: number + optional suffix: us/ms/s/m/h/d)"
+    "source","string","false","\-","\-","Source address for connections to this server"
+    "linked_resolver","string","false","\-","\-","**NEW**: Resolver name to use for server name resolution - supports automatic UUID resolution"
+    "unix_socket","string","false","\-","\-","**NEW**: Frontend name for Unix socket binding - supports automatic UUID resolution"
+    "advanced","string","false","\-","\-","Advanced HAProxy server configuration options"
+
+Usage
+*****
+
+This module manages individual HAProxy server configurations on OPNsense. Servers are backend endpoints that handle client requests routed through HAProxy frontends and backends.
+
+Key features:
+
+- **Automatic UUID Resolution**: All relationship fields accept names and automatically resolve to UUIDs
+- **Name-based Linking**: Users can specify resolver names and frontend names instead of UUIDs
+- **UI Compatibility**: All selections appear correctly in the OPNsense web interface
+- **Server endpoint definition**: Configure IP addresses and ports for backend services
+- **Health monitoring**: Set up health checks with custom intervals and failure detection
+- **Load balancing**: Control server weights and traffic distribution
+- **SSL backend connections**: Enable encrypted connections to backend servers
+- **Connection control**: Manage source addresses and connection parameters
+- **Resolver integration**: Link servers to specific DNS resolvers for dynamic resolution
+- **Unix socket support**: Connect to Unix domain sockets via frontend names
+- **Server states**: Enable/disable servers without removing configuration
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_server'
+
+      tasks:
+        - name: Create basic web server
+          ansibleguy.opnsense.haproxy_server:
+            name: "web01"
+            description: "Primary web server"
+            enabled: true
+            address: "192.168.1.10"
+            port: 80
+            weight: 10
+            check_interval: "5s"
+
+        - name: Create SSL backend server
+          ansibleguy.opnsense.haproxy_server:
+            name: "api_server"
+            description: "API server with SSL"
+            enabled: true
+            address: "api.internal.com"
+            port: 443
+            ssl: true
+            ssl_ca: "{{ ca_cert_uuid }}"
+            weight: 5
+
+        - name: Create database server with custom health check
+          ansibleguy.opnsense.haproxy_server:
+            name: "db_server"
+            description: "PostgreSQL database server"
+            enabled: true
+            address: "10.0.2.5"
+            port: 5432
+            weight: 1
+            check_interval: "10s"
+            check_down_interval: "5s"
+            source: "10.0.1.100"
+
+        - name: Create server with name-based resolver linking
+          ansibleguy.opnsense.haproxy_server:
+            name: "dynamic_server"
+            description: "Server with dynamic DNS resolution"
+            enabled: true
+            address: "app.example.com"
+            port: 8080
+            weight: 10
+            linked_resolver: "cloudflare_resolver"  # Uses resolver name, not UUID
+            check_interval: "5s"
+
+        - name: Create Unix socket server with frontend linking
+          ansibleguy.opnsense.haproxy_server:
+            name: "local_service"
+            description: "Local service via Unix socket"
+            enabled: true
+            address: "/var/run/app.sock"
+            port: 80
+            unix_socket: "unix_frontend"  # Uses frontend name, not UUID
+            weight: 15
+
+        - name: Create server with advanced configuration
+          ansibleguy.opnsense.haproxy_server:
+            name: "custom_server"
+            description: "Server with advanced options"
+            enabled: true
+            address: "192.168.2.20"
+            port: 8080
+            weight: 8
+            advanced: |
+              backup
+              maxconn 100
+              send-proxy
+
+        - name: Disable server temporarily
+          ansibleguy.opnsense.haproxy_server:
+            name: "maintenance_server"
+            enabled: false
+
+        - name: Remove old server
+          ansibleguy.opnsense.haproxy_server:
+            name: "deprecated_server"
+            state: absent
+
+        - name: List all servers
+          ansibleguy.opnsense.list:
+          register: haproxy_servers
+
+        - name: Show servers
+          ansible.builtin.debug:
+            var: haproxy_servers.data

--- a/docs/source/modules/haproxy_server.rst
+++ b/docs/source/modules/haproxy_server.rst
@@ -14,10 +14,6 @@ HAProxy Server
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_server.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_service.rst
+++ b/docs/source/modules/haproxy_service.rst
@@ -14,10 +14,6 @@ HAProxy Service
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_service.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_service.rst
+++ b/docs/source/modules/haproxy_service.rst
@@ -1,0 +1,90 @@
+.. _modules_haproxy_service:
+
+.. include:: ../_include/head.rst
+
+================
+HAProxy Service
+================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_service.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "action","string","true","\-","\-","Service action (start, stop, restart, reload, status, configtest)"
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module controls the HAProxy service operations. It allows you to start, stop, restart, reload the service, check its status, and test the configuration validity.
+
+**Note**: This module does not use the standard 'reload' parameter as it manages service operations directly.
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Check HAProxy service status
+          ansibleguy.opnsense.haproxy_service:
+            action: status
+          register: haproxy_status
+
+        - name: Test HAProxy configuration
+          ansibleguy.opnsense.haproxy_service:
+            action: configtest
+          register: config_test
+
+        - name: Start HAProxy service
+          ansibleguy.opnsense.haproxy_service:
+            action: start
+          when: haproxy_status.result.status != 'running'
+
+        - name: Stop HAProxy service
+          ansibleguy.opnsense.haproxy_service:
+            action: stop
+
+        - name: Restart HAProxy service
+          ansibleguy.opnsense.haproxy_service:
+            action: restart
+
+        - name: Reload HAProxy configuration
+          ansibleguy.opnsense.haproxy_service:
+            action: reload
+
+        - name: Show service status
+          ansible.builtin.debug:
+            var: haproxy_status.result

--- a/docs/source/modules/haproxy_statistics.rst
+++ b/docs/source/modules/haproxy_statistics.rst
@@ -1,0 +1,142 @@
+.. _modules_haproxy_statistics:
+
+.. include:: ../_include/head.rst
+
+=====================
+HAProxy Statistics
+=====================
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_statistics.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "stat_type","string","true","\-","\-","Type of statistics to retrieve (counters, info, tables)"
+    "table_name","string","false","\-","\-","Specific table name when stat_type is 'tables'"
+
+.. include:: ../_include/param_basic.rst
+
+Usage
+*****
+
+This module retrieves real-time HAProxy statistics from OPNsense. It provides access to different types of operational data for monitoring and troubleshooting purposes.
+
+Available statistics types:
+
+- **counters**: Connection counters, session statistics, and performance metrics
+- **info**: General HAProxy information including version, uptime, and global status
+- **tables**: Stick tables and other HAProxy internal data structures
+
+Key features:
+
+- **Real-time monitoring**: Get current HAProxy operational statistics
+- **Performance metrics**: Access connection counts, session data, and throughput information
+- **Health monitoring**: Check service status and uptime information
+- **Table inspection**: Examine HAProxy internal state and stick tables
+- **Read-only operations**: Safe monitoring without configuration changes
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+      tasks:
+        - name: Get HAProxy connection counters
+          ansibleguy.opnsense.haproxy_statistics:
+            stat_type: counters
+          register: haproxy_counters
+
+        - name: Display connection statistics
+          ansible.builtin.debug:
+            msg: |
+              Total connections: {{ haproxy_counters.statistics.total_connections | default('N/A') }}
+              Active sessions: {{ haproxy_counters.statistics.active_sessions | default('N/A') }}
+              Current queue: {{ haproxy_counters.statistics.current_queue | default('N/A') }}
+
+        - name: Get HAProxy system information
+          ansibleguy.opnsense.haproxy_statistics:
+            stat_type: info
+          register: haproxy_info
+
+        - name: Display HAProxy info
+          ansible.builtin.debug:
+            msg: |
+              HAProxy version: {{ haproxy_info.statistics.version | default('Unknown') }}
+              Uptime: {{ haproxy_info.statistics.uptime | default('Unknown') }}
+              Process ID: {{ haproxy_info.statistics.pid | default('Unknown') }}
+              Max connections: {{ haproxy_info.statistics.max_connections | default('Unknown') }}
+
+        - name: Get HAProxy tables data
+          ansibleguy.opnsense.haproxy_statistics:
+            stat_type: tables
+          register: haproxy_tables
+
+        - name: Display available tables
+          ansible.builtin.debug:
+            var: haproxy_tables.statistics
+
+        - name: Get specific table information
+          ansibleguy.opnsense.haproxy_statistics:
+            stat_type: tables
+            table_name: "backend_sessions"
+          register: backend_table
+          when: haproxy_tables.statistics.tables is defined
+
+        - name: Monitor HAProxy health
+          ansibleguy.opnsense.haproxy_statistics:
+            stat_type: info
+          register: health_check
+          failed_when: health_check.statistics.status is defined and health_check.statistics.status != 'running'
+
+        - name: Collect performance metrics
+          block:
+            - name: Get counters
+              ansibleguy.opnsense.haproxy_statistics:
+                stat_type: counters
+              register: metrics
+
+            - name: Alert on high connection count
+              ansible.builtin.debug:
+                msg: "WARNING: High connection count detected"
+              when: 
+                - metrics.statistics.total_connections is defined
+                - metrics.statistics.total_connections | int > 10000
+
+        - name: Generate monitoring report
+          ansible.builtin.template:
+            src: haproxy_report.j2
+            dest: /tmp/haproxy_status.html
+          vars:
+            counters: "{{ haproxy_counters.statistics }}"
+            info: "{{ haproxy_info.statistics }}"
+            tables: "{{ haproxy_tables.statistics }}"

--- a/docs/source/modules/haproxy_statistics.rst
+++ b/docs/source/modules/haproxy_statistics.rst
@@ -14,10 +14,6 @@ HAProxy Statistics
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_statistics.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_user.rst
+++ b/docs/source/modules/haproxy_user.rst
@@ -14,10 +14,6 @@ HAProxy User
 
 **TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_user.yml>`_
 
-**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
-
-**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
-
 
 Contribution
 ************

--- a/docs/source/modules/haproxy_user.rst
+++ b/docs/source/modules/haproxy_user.rst
@@ -1,0 +1,148 @@
+.. _modules_haproxy_user:
+
+.. include:: ../_include/head.rst
+
+=============
+HAProxy User
+=============
+
+**STATE**: stable
+
+**COMPATIBILITY**: OPNsense 24.1+
+
+**Note**: Most functions should work on earlier OPNsense versions, but full compatibility is tested with OPNsense 24.1+. For compatibility with earlier versions, please check the configuration differences at: `HAProxy Configuration Reference <https://github.com/opnsense/plugins/blob/master/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml>`_
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible_opnsense/blob/latest/tests/haproxy_user.yml>`_
+
+**API Docs**: `HAProxy <https://docs.opnsense.org/development/api/plugins/haproxy.html>`_
+
+**Service Docs**: `HAProxy <https://docs.opnsense.org/manual/how-tos/haproxy.html>`_
+
+
+Contribution
+************
+
+This module was contributed by **MaximeWewer** (@MaximeWewer).
+
+If you encounter any issues or have suggestions for improvements, please feel free to contribute to the project.
+
+
+Definition
+**********
+
+.. include:: ../_include/param_basic.rst
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "name","string","true","\-","\-","User name (unique identifier)"
+    "description","string","false","\-","\-","User description"
+    "enabled","boolean","false","true","\-","Enable or disable user"
+    "password","string","true","\-","\-","User password for authentication"
+
+Usage
+*****
+
+This module manages HAProxy users on OPNsense for authentication and authorization purposes. Users are used in conjunction with groups and ACLs to control access to HAProxy services.
+
+Key features:
+
+- **User authentication**: Create users for HTTP authentication in HAProxy
+- **Group integration**: Users can be assigned to groups for organized access control
+- **Password management**: Secure password configuration for user authentication
+- **ACL compatibility**: Users work seamlessly with HAProxy ACLs for access control
+- **UI integration**: Users appear correctly in the OPNsense web interface
+- **Userlist management**: Users are automatically added to HAProxy userlists when needed
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: localhost
+      gather_facts: false
+      module_defaults:
+        group/ansibleguy.opnsense.all:
+          firewall: 'opnsense.template.ansibleguy.net'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        ansibleguy.opnsense.list:
+          target: 'haproxy_user'
+
+      tasks:
+        - name: Create admin user
+          ansibleguy.opnsense.haproxy_user:
+            name: 'admin'
+            description: 'Administrator user'
+            enabled: true
+            password: 'secure_password_123'
+
+        - name: Create operator user
+          ansibleguy.opnsense.haproxy_user:
+            name: 'operator'
+            description: 'System operator'
+            enabled: true
+            password: 'operator_secure_pass'
+
+        - name: Create readonly user
+          ansibleguy.opnsense.haproxy_user:
+            name: 'readonly'
+            description: 'Read-only user'
+            enabled: true
+            password: 'readonly_pass'
+
+        - name: Create API user
+          ansibleguy.opnsense.haproxy_user:
+            name: 'api_user'
+            description: 'User for API access'
+            enabled: true
+            password: 'api_strong_password'
+
+        - name: Create security auditor
+          ansibleguy.opnsense.haproxy_user:
+            name: 'security_admin'
+            description: 'Security team member'
+            enabled: true
+            password: 'security_complex_pass'
+
+        - name: Create development team users
+          ansibleguy.opnsense.haproxy_user:
+            name: "{{ item.name }}"
+            description: "{{ item.desc }}"
+            enabled: true
+            password: "{{ item.password }}"
+          loop:
+            - { name: 'alice', desc: 'Developer Alice', password: 'alice_dev_pass' }
+            - { name: 'bob', desc: 'Developer Bob', password: 'bob_dev_pass' }
+            - { name: 'charlie', desc: 'Developer Charlie', password: 'charlie_dev_pass' }
+
+        - name: Create guest user (disabled by default)
+          ansibleguy.opnsense.haproxy_user:
+            name: 'guest'
+            description: 'Guest user for temporary access'
+            enabled: false
+            password: 'guest_temp_pass'
+
+        - name: Update user password
+          ansibleguy.opnsense.haproxy_user:
+            name: 'admin'
+            password: 'new_secure_password_456'
+
+        - name: Disable user temporarily
+          ansibleguy.opnsense.haproxy_user:
+            name: 'readonly'
+            enabled: false
+
+        - name: Remove old user
+          ansibleguy.opnsense.haproxy_user:
+            name: 'deprecated_user'
+            state: absent
+
+        - name: List all users
+          ansibleguy.opnsense.list:
+          register: haproxy_users
+
+        - name: Show users
+          ansible.builtin.debug:
+            var: haproxy_users.data

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -159,6 +159,27 @@ action_groups:
   hasync:
     - ansibleguy.opnsense.hasync_general
     - ansibleguy.opnsense.hasync_service
+  haproxy:
+    - ansibleguy.opnsense.haproxy_general
+    - ansibleguy.opnsense.haproxy_backend
+    - ansibleguy.opnsense.haproxy_server
+    - ansibleguy.opnsense.haproxy_frontend
+    - ansibleguy.opnsense.haproxy_service
+    - ansibleguy.opnsense.haproxy_statistics
+    - ansibleguy.opnsense.haproxy_maintenance
+    - ansibleguy.opnsense.haproxy_exporter
+    - ansibleguy.opnsense.haproxy_acl
+    - ansibleguy.opnsense.haproxy_user
+    - ansibleguy.opnsense.haproxy_group
+    - ansibleguy.opnsense.haproxy_errorfile
+    - ansibleguy.opnsense.haproxy_healthcheck
+    - ansibleguy.opnsense.haproxy_mapfile
+    - ansibleguy.opnsense.haproxy_resolver
+    - ansibleguy.opnsense.haproxy_mailer
+    - ansibleguy.opnsense.haproxy_action
+    - ansibleguy.opnsense.haproxy_lua
+    - ansibleguy.opnsense.haproxy_fcgi
+    - ansibleguy.opnsense.haproxy_cpu
   raw:
     - ansibleguy.opnsense.raw
   all:
@@ -187,6 +208,7 @@ action_groups:
           - ansibleguy.opnsense.acme
           - ansibleguy.opnsense.postfix
           - ansibleguy.opnsense.hasync
+          - ansibleguy.opnsense.haproxy
           - ansibleguy.opnsense.raw
 
 plugin_routing:

--- a/plugins/module_utils/main/haproxy_acl.py
+++ b/plugins/module_utils/main/haproxy_acl.py
@@ -1,0 +1,196 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyAcl(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addAcl',
+        'del': 'delAcl',
+        'set': 'setAcl',
+        'search': 'searchAcls',
+        'detail': 'getAcl',
+        'toggle': 'toggleAcl',
+    }
+    API_KEY_PATH = 'acl'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['description', 'expression', 'negate', 'caseSensitive', 
+                     'hdr_beg', 'hdr_end', 'hdr', 'hdr_reg', 'hdr_sub',
+                     'path_beg', 'path_end', 'path', 'path_reg', 'path_dir', 'path_sub',
+                     'cust_hdr_beg', 'cust_hdr_end', 'cust_hdr', 'cust_hdr_reg', 'cust_hdr_sub',
+                     'url_param', 'ssl_c_verify_code', 'ssl_c_ca_commonname', 'ssl_hello_type',
+                     'src', 'src_port', 'allowedUsers', 'allowedGroups']
+    FIELDS_ALL = ['name', 'description', 'expression', 'negate']
+    FIELDS_TRANSLATE = {
+        'description': 'description', 
+        'name': 'name',
+        'expression': 'expression',
+        'negate': 'negate'
+    }
+    FIELDS_TYPING = {}
+    EXIST_ATTR = 'acl'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.acl = {}
+        self.diff = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create an ACL!')
+
+            if is_unset(self.p['expression']):
+                self.m.fail_json('You need to provide an expression to create an ACL!')
+
+            # Validate that value is provided for expressions that require it
+            if self.p['expression'] not in ['ssl_c_verify', 'src_is_local'] and is_unset(self.p['value']):
+                if self.p['expression'] != 'http_auth':
+                    self.m.fail_json(f'Expression "{self.p["expression"]}" requires a value!')
+
+            # Validate auth-specific fields
+            if self.p['expression'] == 'http_auth':
+                if is_unset(self.p['allowedUsers']) and is_unset(self.p['allowedGroups']):
+                    self.m.fail_json('HTTP auth expression requires allowedUsers or allowedGroups!')
+
+        self._base_check()
+
+    def _build_request(self) -> dict:
+        """
+        Override request building to map value to the correct expression-specific field.
+        """
+        # Map expression types to their corresponding API field names
+        expression_field_map = {
+            'hdr_beg': 'hdr_beg',
+            'hdr_end': 'hdr_end', 
+            'hdr': 'hdr',
+            'hdr_reg': 'hdr_reg',
+            'hdr_sub': 'hdr_sub',
+            'path_beg': 'path_beg',
+            'path_end': 'path_end',
+            'path': 'path',
+            'path_reg': 'path_reg',
+            'path_dir': 'path_dir',
+            'path_sub': 'path_sub',
+            'src': 'src',
+            'src_port': 'src_port',
+            'url_param': 'url_param',
+            'ssl_c_verify_code': 'ssl_c_verify_code',
+            'ssl_c_ca_commonname': 'ssl_c_ca_commonname',
+            'ssl_hello_type': 'ssl_hello_type'
+        }
+        
+        # Build base request data
+        request_data = {
+            'name': self.p['name'],
+            'description': self.p.get('description', ''),
+            'expression': self.p['expression'],
+            'negate': '1' if self.p.get('negate', False) else '0',
+            'caseSensitive': '1' if self.p.get('case_sensitive', False) else '0'
+        }
+        
+        # Map value to the correct field based on expression type
+        expression = self.p['expression']
+        if expression in expression_field_map and 'value' in self.p and self.p['value']:
+            api_field = expression_field_map[expression]
+            request_data[api_field] = self.p['value']
+        
+        # Handle special cases for custom headers
+        if expression.startswith('cust_hdr') and 'value' in self.p and self.p['value']:
+            # For custom headers, we need to split the value into header name and value
+            if ' ' in self.p['value']:
+                header_name, header_value = self.p['value'].split(' ', 1)
+                request_data[f'{expression}_name'] = header_name
+                request_data[expression] = header_value
+            else:
+                request_data[f'{expression}_name'] = self.p['value']
+        
+        # Handle authentication fields with UUID resolution
+        if expression == 'http_auth':
+            if 'allowedUsers' in self.p and self.p['allowedUsers']:
+                user_uuids = self._resolve_user_names(self.p['allowedUsers'])
+                if user_uuids:
+                    request_data['allowedUsers'] = ','.join(user_uuids)
+            if 'allowedGroups' in self.p and self.p['allowedGroups']:
+                group_uuids = self._resolve_group_names(self.p['allowedGroups'])
+                if group_uuids:
+                    request_data['allowedGroups'] = ','.join(group_uuids)
+        
+        return {self.API_KEY_PATH: request_data}
+    
+    def _resolve_user_names(self, user_names: list) -> list:
+        """
+        Resolve user names to UUIDs by fetching the user list.
+        """
+        if not user_names:
+            return []
+        
+        try:
+            users_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchUsers'
+            })
+            
+            if 'rows' in users_response:
+                user_uuids = []
+                for user_name in user_names:
+                    for user in users_response['rows']:
+                        if user.get('name') == user_name:
+                            user_uuids.append(user.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"User '{user_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved users: {dict(zip(user_names, user_uuids))}")
+                
+                return user_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve user names: {str(e)}")
+        
+        return []
+    
+    def _resolve_group_names(self, group_names: list) -> list:
+        """
+        Resolve group names to UUIDs by fetching the group list.
+        """
+        if not group_names:
+            return []
+        
+        try:
+            groups_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchGroups'
+            })
+            
+            if 'rows' in groups_response:
+                group_uuids = []
+                for group_name in group_names:
+                    for group in groups_response['rows']:
+                        if group.get('name') == group_name:
+                            group_uuids.append(group.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Group '{group_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved groups: {dict(zip(group_names, group_uuids))}")
+                
+                return group_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve group names: {str(e)}")
+        
+        return []

--- a/plugins/module_utils/main/haproxy_action.py
+++ b/plugins/module_utils/main/haproxy_action.py
@@ -1,0 +1,202 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyAction(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addAction',
+        'del': 'delAction',
+        'set': 'setAction',
+        'search': 'searchActions',
+        'detail': 'getAction',
+        'toggle': 'toggleAction',
+    }
+    API_KEY_PATH = 'action'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = [
+        'description', 'action_type', 'test_type', 'linked_acls', 'operator',
+        'use_backend', 'use_server', 'http_request_auth', 'http_request_redirect',
+        'http_request_lua', 'custom_lua', 'map_use_backend_file', 'map_use_backend_default'
+    ]
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'name': 'name',
+        'description': 'description',
+        'action_type': 'type',
+        'test_type': 'testType',
+        'linked_acls': 'linkedAcls',
+        'operator': 'operator',
+        'use_backend': 'useBackend',
+        'use_server': 'useServer',
+        'http_request_auth': 'http_request_auth',
+        'http_request_redirect': 'http_request_redirect',
+        'http_request_lua': 'http_request_lua',
+        'custom_lua': 'custom',
+        'map_use_backend_file': 'map_use_backend_file',
+        'map_use_backend_default': 'map_use_backend_default'
+    }
+    FIELDS_TYPING = {}
+    EXIST_ATTR = 'action'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.action = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create an action!')
+            
+            if is_unset(self.p['action_type']):
+                self.m.fail_json('You need to provide an action_type!')
+
+        self._base_check()
+
+    def _build_request(self) -> dict:
+        """
+        Override request building to handle backend and server linking.
+        """
+        # Build base request
+        request_data = {}
+        
+        # Handle basic fields
+        for field in ['name', 'description', 'test_type', 'operator', 'action_type']:
+            if field in self.p and self.p[field] is not None:
+                api_field = self.FIELDS_TRANSLATE.get(field, field)
+                request_data[api_field] = self.p[field]
+        
+        # Handle string fields for actions
+        for field in ['http_request_auth', 'http_request_redirect', 'http_request_lua', 'custom_lua']:
+            if field in self.p and self.p[field] is not None:
+                api_field = self.FIELDS_TRANSLATE.get(field, field)
+                request_data[api_field] = self.p[field]
+        
+        # Handle linked ACLs - resolve names to UUIDs
+        if 'linked_acls' in self.p and self.p['linked_acls']:
+            acl_uuids = self._resolve_acl_names(self.p['linked_acls'])
+            if acl_uuids:
+                request_data['linkedAcls'] = ','.join(acl_uuids)
+        
+        # Handle use_backend - resolve backend name to UUID
+        # IMPORTANT: OPNsense UI uses 'use_backend' (underscore) NOT 'useBackend' (camelCase)
+        if 'use_backend' in self.p and self.p['use_backend']:
+            backend_uuid = self._resolve_backend_name(self.p['use_backend'])
+            if backend_uuid:
+                # Use underscore version for UI compatibility
+                request_data['use_backend'] = backend_uuid
+        
+        # Handle use_server - resolve server names to UUIDs
+        if 'use_server' in self.p and self.p['use_server']:
+            server_uuids = self._resolve_server_names(self.p['use_server'])
+            if server_uuids:
+                request_data['useServer'] = ','.join(server_uuids)
+        
+        # Handle map backend fields - resolve backend names to UUIDs
+        if 'map_use_backend_default' in self.p and self.p['map_use_backend_default']:
+            backend_uuid = self._resolve_backend_name(self.p['map_use_backend_default'])
+            if backend_uuid:
+                request_data['map_use_backend_default'] = backend_uuid
+        
+        return {self.API_KEY_PATH: request_data}
+    
+    def _resolve_backend_name(self, backend_name: str) -> str:
+        """
+        Resolve backend name to UUID by fetching the backend list.
+        """
+        if not backend_name:
+            return ''
+        
+        try:
+            # Get all backends
+            backends_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchBackends'
+            })
+            
+            if 'rows' in backends_response:
+                for backend in backends_response['rows']:
+                    if backend.get('name') == backend_name:
+                        return backend.get('uuid', '')
+                
+                self.m.warn(f"Backend '{backend_name}' not found")
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve backend name: {str(e)}")
+        
+        return ''
+    
+    def _resolve_acl_names(self, acl_names: list) -> list:
+        """
+        Resolve ACL names to UUIDs by fetching the ACL list.
+        """
+        if not acl_names:
+            return []
+        
+        try:
+            # Get all ACLs
+            acls_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchAcls'
+            })
+            
+            if 'rows' in acls_response:
+                acl_uuids = []
+                for acl_name in acl_names:
+                    for acl in acls_response['rows']:
+                        if acl.get('name') == acl_name:
+                            acl_uuids.append(acl.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"ACL '{acl_name}' not found, skipping")
+                
+                return acl_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve ACL names: {str(e)}")
+        
+        return []
+    
+    def _resolve_server_names(self, server_names: list) -> list:
+        """
+        Resolve server names to UUIDs by fetching the server list.
+        """
+        if not server_names:
+            return []
+        
+        try:
+            # Get all servers
+            servers_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchServers'
+            })
+            
+            if 'rows' in servers_response:
+                server_uuids = []
+                for server_name in server_names:
+                    for server in servers_response['rows']:
+                        if server.get('name') == server_name:
+                            server_uuids.append(server.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Server '{server_name}' not found, skipping")
+                
+                return server_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve server names: {str(e)}")
+        
+        return []

--- a/plugins/module_utils/main/haproxy_backend.py
+++ b/plugins/module_utils/main/haproxy_backend.py
@@ -1,0 +1,314 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyBackend(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addBackend',
+        'del': 'delBackend', 
+        'set': 'setBackend',
+        'search': 'searchBackends',
+        'detail': 'getBackend',
+        'toggle': 'toggleBackend',
+    }
+    API_KEY_PATH = 'backend'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = [
+        'enabled', 'description', 'mode', 'algorithm', 'source', 
+        'linked_servers', 'linked_actions', 'linked_errorfiles', 'basic_auth_users', 'basic_auth_groups',
+        'health_check_enabled', 'health_check_interval', 
+        'health_check_timeout', 'health_check_retries', 'http_reuse'
+    ]
+    FIELDS_ALL = ['name', 'enabled', 'description', 'mode', 'algorithm']
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name',
+        'mode': 'mode',
+        'algorithm': 'algorithm',
+        'source': 'source',
+        'linked_servers': 'linkedServers',
+        'linked_actions': 'linkedActions',
+        'linked_errorfiles': 'linkedErrorfiles', 
+        'basic_auth_users': 'basicAuthUsers',
+        'basic_auth_groups': 'basicAuthGroups',
+        'health_check_enabled': 'healthCheckEnabled',
+        'health_check_interval': 'checkInterval',
+        'health_check_timeout': 'tuning_timeoutCheck',
+        'health_check_retries': 'tuning_retries',
+        'http_reuse': 'tuning_httpreuse'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'backend'
+    TIMEOUT = 60.0
+    
+    INT_VALIDATIONS = {
+        'health_check_retries': {'min': 1, 'max': 10},
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.backend = {}
+
+    def check(self) -> None:
+        # Validate time format for intervals
+        if not is_unset(self.p['health_check_interval']):
+            import re
+            if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['health_check_interval']):
+                self.m.fail_json(
+                    f"Value of health_check_interval '{self.p['health_check_interval']}' is invalid."
+                )
+        
+        if not is_unset(self.p['health_check_timeout']):
+            import re
+            if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['health_check_timeout']):
+                self.m.fail_json(
+                    f"Value of health_check_timeout '{self.p['health_check_timeout']}' is invalid."
+                )
+        
+        self._base_check()
+
+    def _build_request(self) -> dict:
+        """
+        Override request building to handle server linking.
+        """
+        # Build base request
+        request_data = {}
+        
+        # Handle basic fields
+        for field in ['name', 'description', 'mode', 'algorithm', 'source']:
+            if field in self.p and self.p[field] is not None:
+                api_field = self.FIELDS_TRANSLATE.get(field, field)
+                request_data[api_field] = self.p[field]
+        
+        # Handle boolean fields
+        for field in ['enabled', 'health_check_enabled']:
+            if field in self.p:
+                api_field = self.FIELDS_TRANSLATE.get(field, field)
+                request_data[api_field] = '1' if self.p[field] else '0'
+        
+        # Handle health check fields
+        for field in ['health_check_interval', 'health_check_timeout', 'health_check_retries']:
+            if field in self.p and self.p[field] is not None:
+                api_field = self.FIELDS_TRANSLATE.get(field, field)
+                request_data[api_field] = str(self.p[field])
+        
+        # Handle http_reuse
+        if 'http_reuse' in self.p and self.p['http_reuse']:
+            request_data['tuning_httpreuse'] = self.p['http_reuse']
+        
+        # Handle linked servers - resolve names to UUIDs
+        if 'linked_servers' in self.p and self.p['linked_servers']:
+            server_uuids = self._resolve_server_names(self.p['linked_servers'])
+            if server_uuids:
+                # Join UUIDs with comma for HAProxy API
+                request_data['linkedServers'] = ','.join(server_uuids)
+        
+        # Handle linked actions - resolve names to UUIDs
+        # IMPORTANT: Use 'linkedActions' (camelCase) for backend - different from frontend 'linked_actions'
+        if 'linked_actions' in self.p and self.p['linked_actions']:
+            action_uuids = self._resolve_action_names(self.p['linked_actions'])
+            if action_uuids:
+                request_data['linkedActions'] = ','.join(action_uuids)
+        
+        # Handle linked errorfiles - resolve names to UUIDs  
+        if 'linked_errorfiles' in self.p and self.p['linked_errorfiles']:
+            errorfile_uuids = self._resolve_errorfile_names(self.p['linked_errorfiles'])
+            if errorfile_uuids:
+                request_data['linkedErrorfiles'] = ','.join(errorfile_uuids)
+        
+        # Handle basic auth users - resolve names to UUIDs
+        if 'basic_auth_users' in self.p and self.p['basic_auth_users']:
+            user_uuids = self._resolve_user_names(self.p['basic_auth_users'])
+            if user_uuids:
+                request_data['basicAuthUsers'] = ','.join(user_uuids)
+        
+        # Handle basic auth groups - resolve names to UUIDs
+        if 'basic_auth_groups' in self.p and self.p['basic_auth_groups']:
+            group_uuids = self._resolve_group_names(self.p['basic_auth_groups'])
+            if group_uuids:
+                request_data['basicAuthGroups'] = ','.join(group_uuids)
+        
+        return {self.API_KEY_PATH: request_data}
+    
+    def _resolve_server_names(self, server_names: list) -> list:
+        """
+        Resolve server names to UUIDs by fetching the server list.
+        """
+        if not server_names:
+            return []
+        
+        try:
+            # Get all servers
+            servers_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchServers'
+            })
+            
+            if 'rows' in servers_response:
+                server_uuids = []
+                for server_name in server_names:
+                    for server in servers_response['rows']:
+                        if server.get('name') == server_name:
+                            server_uuids.append(server.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Server '{server_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved servers: {dict(zip(server_names, server_uuids))}")
+                
+                return server_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve server names: {str(e)}")
+        
+        return []
+    
+    def _resolve_action_names(self, action_names: list) -> list:
+        """
+        Resolve action names to UUIDs by fetching the action list.
+        """
+        if not action_names:
+            return []
+        
+        try:
+            actions_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchActions'
+            })
+            
+            if 'rows' in actions_response:
+                action_uuids = []
+                for action_name in action_names:
+                    for action in actions_response['rows']:
+                        if action.get('name') == action_name:
+                            action_uuids.append(action.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Action '{action_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved actions: {dict(zip(action_names, action_uuids))}")
+                
+                return action_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve action names: {str(e)}")
+        
+        return []
+    
+    def _resolve_errorfile_names(self, errorfile_names: list) -> list:
+        """
+        Resolve errorfile names to UUIDs by fetching the errorfile list.
+        """
+        if not errorfile_names:
+            return []
+        
+        try:
+            errorfiles_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchErrorfiles'
+            })
+            
+            if 'rows' in errorfiles_response:
+                errorfile_uuids = []
+                for errorfile_name in errorfile_names:
+                    for errorfile in errorfiles_response['rows']:
+                        if errorfile.get('name') == errorfile_name:
+                            errorfile_uuids.append(errorfile.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Errorfile '{errorfile_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved errorfiles: {dict(zip(errorfile_names, errorfile_uuids))}")
+                
+                return errorfile_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve errorfile names: {str(e)}")
+        
+        return []
+    
+    def _resolve_user_names(self, user_names: list) -> list:
+        """
+        Resolve user names to UUIDs by fetching the user list.
+        """
+        if not user_names:
+            return []
+        
+        try:
+            users_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchUsers'
+            })
+            
+            if 'rows' in users_response:
+                user_uuids = []
+                for user_name in user_names:
+                    for user in users_response['rows']:
+                        if user.get('name') == user_name:
+                            user_uuids.append(user.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"User '{user_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved users: {dict(zip(user_names, user_uuids))}")
+                
+                return user_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve user names: {str(e)}")
+        
+        return []
+    
+    def _resolve_group_names(self, group_names: list) -> list:
+        """
+        Resolve group names to UUIDs by fetching the group list.
+        """
+        if not group_names:
+            return []
+        
+        try:
+            groups_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchGroups'
+            })
+            
+            if 'rows' in groups_response:
+                group_uuids = []
+                for group_name in group_names:
+                    for group in groups_response['rows']:
+                        if group.get('name') == group_name:
+                            group_uuids.append(group.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Group '{group_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved groups: {dict(zip(group_names, group_uuids))}")
+                
+                return group_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve group names: {str(e)}")
+        
+        return []

--- a/plugins/module_utils/main/haproxy_cpu.py
+++ b/plugins/module_utils/main/haproxy_cpu.py
@@ -1,0 +1,55 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyCpu(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addCpu',
+        'del': 'delCpu',
+        'set': 'setCpu',
+        'search': 'searchCpus',
+        'detail': 'getCpu',
+        'toggle': 'toggleCpu',
+    }
+    API_KEY_PATH = 'cpu'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'thread_id', 'cpu_id']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'name': 'name',
+        'thread_id': 'thread_id',
+        'cpu_id': 'cpu_id'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'cpu'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.cpu = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a CPU affinity rule!')
+            
+            if is_unset(self.p['thread_id']):
+                self.m.fail_json('You need to provide a thread_id for the CPU affinity rule!')
+                
+            if is_unset(self.p['cpu_id']):
+                self.m.fail_json('You need to provide a cpu_id for the CPU affinity rule!')
+
+        self._base_check()

--- a/plugins/module_utils/main/haproxy_errorfile.py
+++ b/plugins/module_utils/main/haproxy_errorfile.py
@@ -1,0 +1,111 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyErrorfile(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addErrorfile',
+        'del': 'delErrorfile',
+        'set': 'setErrorfile',
+        'search': 'searchErrorfiles',
+        'detail': 'getErrorfile',
+        'toggle': 'toggleErrorfile',
+    }
+    API_KEY_PATH = 'errorfile'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['description', 'code', 'content']
+    FIELDS_ALL = ['name', 'description']
+    FIELDS_TRANSLATE = {
+        'description': 'description', 
+        'name': 'name'
+    }
+    FIELDS_TYPING = {
+        'select': ['code']
+    }
+    EXIST_ATTR = 'errorfile'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.errorfile = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create an error file!')
+
+            if is_unset(self.p['code']):
+                self.m.fail_json('You need to provide a code to create an error file!')
+
+            if is_unset(self.p['content']):
+                self.m.fail_json('You need to provide content to create an error file!')
+
+        self._base_check()
+
+    def _search_call(self) -> list:
+        """
+        Override _search_call method which is called by Base.find().
+        The search API only returns name, description, uuid but not code/content.
+        """
+        try:
+            response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': self.CMDS['search']
+            })
+            
+            if 'rows' in response:
+                return response['rows']
+            return []
+            
+        except Exception as e:
+            self.m.warn(f"Search API failed: {str(e)}")
+            return []
+    
+    def simplify_existing(self, existing: dict) -> dict:
+        """
+        Override simplify_existing to only process fields available from search API.
+        ErrorFiles search API only returns name, description, uuid - not code/content.
+        """
+        simplified = {}
+        available_fields = ['name', 'description', 'uuid']
+        
+        for field in available_fields:
+            if field in existing:
+                simplified[field] = existing[field]
+        
+        return simplified
+
+    def update(self) -> None:
+        """
+        Override update to handle ErrorFiles properly.
+        Since API inconsistency prevents proper update detection, always recreate.
+        """
+        if self.exists:
+            # Delete existing entry first
+            self.b.delete()
+        
+        # Create new entry
+        self.create()
+
+    def _build_request(self) -> dict:
+        """
+        Override request building to include all required fields for ErrorFiles.
+        """
+        return {
+            self.API_KEY_PATH: {
+                'name': self.p['name'],
+                'description': self.p.get('description', ''),
+                'code': self.p['code'],
+                'content': self.p['content']
+            }
+        }

--- a/plugins/module_utils/main/haproxy_exporter.py
+++ b/plugins/module_utils/main/haproxy_exporter.py
@@ -1,0 +1,81 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+
+
+class HaproxyExporter:
+    """HAProxy export operations class"""
+    
+    API_MOD = 'haproxy'
+    API_CONT = 'export'
+    TIMEOUT = 60.0
+    
+    EXPORT_COMMANDS = {
+        'config': 'config',
+        'diff': 'diff',
+        'download': 'download',
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        self.m = module
+        self.r = result
+        self.p = module.params
+        self.s = Session(module=module, timeout=self.TIMEOUT) if session is None else session
+        
+        if 'diff' not in self.r:
+            self.r['diff'] = {'before': {}, 'after': {}}
+
+    def check(self) -> None:
+        """Validate parameters"""
+        if is_unset(self.p['export_type']):
+            self.m.fail_json('You need to provide an export_type!')
+        
+        if self.p['export_type'] not in self.EXPORT_COMMANDS:
+            self.m.fail_json(f'Invalid export_type: {self.p["export_type"]}')
+        
+        # For download type, validate download_type parameter
+        if self.p['export_type'] == 'download' and is_unset(self.p.get('download_type')):
+            self.m.fail_json('You need to provide a download_type when export_type is "download"!')
+
+    def process(self) -> None:
+        """Execute the export operation"""
+        export_type = self.p['export_type']
+        command = self.EXPORT_COMMANDS[export_type]
+        
+        if self.m.check_mode:
+            self.r['result'] = {'status': 'check_mode', 'export_type': export_type}
+            return
+        
+        # Build API call configuration
+        cnf = {
+            'module': self.API_MOD,
+            'controller': self.API_CONT,
+            'command': command,
+        }
+        
+        # Add download type parameter for download operations
+        if export_type == 'download' and not is_unset(self.p.get('download_type')):
+            cnf['params'] = [self.p['download_type']]
+        
+        try:
+            response = self.s.get(cnf=cnf)
+            
+            if self.p.get('debug', False):
+                self.m.warn(f"HAProxy Exporter - {export_type.upper()} RESPONSE: '{response}'")
+            
+            self.r['result'] = response
+            self.r['changed'] = False  # Export operations don't change anything
+                
+        except Exception as e:
+            self.m.fail_json(f'Export operation {export_type} failed: {str(e)}')
+        
+        finally:
+            if hasattr(self, 's'):
+                self.s.close()
+
+    def reload(self) -> None:
+        """Not applicable for export operations"""
+        pass

--- a/plugins/module_utils/main/haproxy_fcgi.py
+++ b/plugins/module_utils/main/haproxy_fcgi.py
@@ -1,0 +1,47 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyFcgi(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addFcgi',
+        'del': 'delFcgi',
+        'set': 'setFcgi',
+        'search': 'searchFcgis',
+        'detail': 'getFcgi',
+        'toggle': 'toggleFcgi',
+    }
+    API_KEY_PATH = 'fcgi'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['description', 'docroot', 'index']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'name': 'name',
+        'description': 'description',
+        'docroot': 'docroot',
+        'index': 'index'
+    }
+    FIELDS_TYPING = {}
+    EXIST_ATTR = 'fcgi'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.fcgi = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create an FCGI app!')
+
+        self._base_check()

--- a/plugins/module_utils/main/haproxy_frontend.py
+++ b/plugins/module_utils/main/haproxy_frontend.py
@@ -1,0 +1,293 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_ip, is_valid_domain, is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyFrontend(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addFrontend',
+        'del': 'delFrontend',
+        'set': 'setFrontend',
+        'search': 'searchFrontends',
+        'detail': 'getFrontend',
+        'toggle': 'toggleFrontend',
+    }
+    API_KEY_PATH = 'frontend'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'description', 'bind', 'mode', 'default_backend', 
+                     'linked_actions', 'linked_errorfiles', 'basic_auth_users', 'basic_auth_groups']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name',
+        'bind': 'bind',
+        'mode': 'mode',
+        'default_backend': 'defaultBackend',
+        'linked_actions': 'linkedActions',
+        'linked_errorfiles': 'linkedErrorfiles',
+        'basic_auth_users': 'basicAuthUsers',
+        'basic_auth_groups': 'basicAuthGroups'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'frontend'
+    TIMEOUT = 60.0
+    
+    INT_VALIDATIONS = {
+        'bind_port': {'min': 1, 'max': 65535},
+        'max_connections': {'min': 1, 'max': 1000000},
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.frontend = {}
+        self.diff = {}
+
+    def check(self) -> None:
+        # Validate bind address
+        if self.p['state'] == 'present':
+            if is_unset(self.p['bind_address']):
+                self.m.fail_json('You need to provide a bind_address to create a frontend!')
+            
+            if not is_ip(self.p['bind_address']) and \
+                    not is_valid_domain(self.p['bind_address']) and \
+                    self.p['bind_address'] not in ['*', '0.0.0.0', '::']:
+                self.m.fail_json(
+                    f"Value of bind_address '{self.p['bind_address']}' is not a valid "
+                    f"IP-Address, domain-name, or wildcard!"
+                )
+        
+        self._prepare_data()
+        self._base_check()
+    
+    def _prepare_data(self):
+        """Prepare data by combining bind_address and bind_port into bind field"""
+        # Combine bind_address and bind_port into single bind field
+        if not is_unset(self.p['bind_address']) and not is_unset(self.p['bind_port']):
+            self.p['bind'] = f"{self.p['bind_address']}:{self.p['bind_port']}"
+    
+    def _build_request(self) -> dict:
+        """
+        Override request building to handle relationship field linking.
+        """
+        # Build base request
+        request_data = {}
+        
+        # Handle basic fields
+        for field in ['name', 'description', 'bind', 'mode']:
+            if field in self.p and self.p[field] is not None:
+                request_data[field] = self.p[field]
+        
+        # Handle boolean fields
+        for field in ['enabled']:
+            if field in self.p:
+                request_data[field] = '1' if self.p[field] else '0'
+        
+        # Handle default backend - resolve name to UUID
+        # IMPORTANT: Use 'defaultBackend' (camelCase) for frontend according to XML schema
+        if 'default_backend' in self.p and self.p['default_backend']:
+            backend_uuid = self._resolve_backend_name(self.p['default_backend'])
+            if backend_uuid:
+                request_data['defaultBackend'] = backend_uuid
+        
+        # Handle linked actions - resolve names to UUIDs
+        # IMPORTANT: Use 'linkedActions' (camelCase) for frontend according to XML schema  
+        if 'linked_actions' in self.p and self.p['linked_actions']:
+            action_uuids = self._resolve_action_names(self.p['linked_actions'])
+            if action_uuids:
+                request_data['linkedActions'] = ','.join(action_uuids)
+        
+        # Handle linked errorfiles - resolve names to UUIDs
+        if 'linked_errorfiles' in self.p and self.p['linked_errorfiles']:
+            errorfile_uuids = self._resolve_errorfile_names(self.p['linked_errorfiles'])
+            if errorfile_uuids:
+                request_data['linkedErrorfiles'] = ','.join(errorfile_uuids)
+        
+        # Handle basic auth users - resolve names to UUIDs
+        if 'basic_auth_users' in self.p and self.p['basic_auth_users']:
+            user_uuids = self._resolve_user_names(self.p['basic_auth_users'])
+            if user_uuids:
+                request_data['basicAuthUsers'] = ','.join(user_uuids)
+        
+        # Handle basic auth groups - resolve names to UUIDs
+        if 'basic_auth_groups' in self.p and self.p['basic_auth_groups']:
+            group_uuids = self._resolve_group_names(self.p['basic_auth_groups'])
+            if group_uuids:
+                request_data['basicAuthGroups'] = ','.join(group_uuids)
+        
+        return {self.API_KEY_PATH: request_data}
+    
+    def _resolve_backend_name(self, backend_name: str) -> str:
+        """
+        Resolve backend name to UUID by fetching the backend list.
+        """
+        if not backend_name:
+            return ''
+        
+        try:
+            backends_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchBackends'
+            })
+            
+            if 'rows' in backends_response:
+                for backend in backends_response['rows']:
+                    if backend.get('name') == backend_name:
+                        if self.p.get('debug', False):
+                            self.m.warn(f"Resolved backend '{backend_name}' to UUID: {backend.get('uuid')}")
+                        return backend.get('uuid')
+                
+                self.m.warn(f"Backend '{backend_name}' not found")
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve backend name: {str(e)}")
+        
+        return ''
+    
+    def _resolve_action_names(self, action_names: list) -> list:
+        """
+        Resolve action names to UUIDs by fetching the action list.
+        """
+        if not action_names:
+            return []
+        
+        try:
+            actions_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchActions'
+            })
+            
+            if 'rows' in actions_response:
+                action_uuids = []
+                for action_name in action_names:
+                    for action in actions_response['rows']:
+                        if action.get('name') == action_name:
+                            action_uuids.append(action.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Action '{action_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved actions: {dict(zip(action_names, action_uuids))}")
+                
+                return action_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve action names: {str(e)}")
+        
+        return []
+    
+    def _resolve_errorfile_names(self, errorfile_names: list) -> list:
+        """
+        Resolve errorfile names to UUIDs by fetching the errorfile list.
+        """
+        if not errorfile_names:
+            return []
+        
+        try:
+            errorfiles_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchErrorfiles'
+            })
+            
+            if 'rows' in errorfiles_response:
+                errorfile_uuids = []
+                for errorfile_name in errorfile_names:
+                    for errorfile in errorfiles_response['rows']:
+                        if errorfile.get('name') == errorfile_name:
+                            errorfile_uuids.append(errorfile.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Errorfile '{errorfile_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved errorfiles: {dict(zip(errorfile_names, errorfile_uuids))}")
+                
+                return errorfile_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve errorfile names: {str(e)}")
+        
+        return []
+    
+    def _resolve_user_names(self, user_names: list) -> list:
+        """
+        Resolve user names to UUIDs by fetching the user list.
+        """
+        if not user_names:
+            return []
+        
+        try:
+            users_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchUsers'
+            })
+            
+            if 'rows' in users_response:
+                user_uuids = []
+                for user_name in user_names:
+                    for user in users_response['rows']:
+                        if user.get('name') == user_name:
+                            user_uuids.append(user.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"User '{user_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved users: {dict(zip(user_names, user_uuids))}")
+                
+                return user_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve user names: {str(e)}")
+        
+        return []
+    
+    def _resolve_group_names(self, group_names: list) -> list:
+        """
+        Resolve group names to UUIDs by fetching the group list.
+        """
+        if not group_names:
+            return []
+        
+        try:
+            groups_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchGroups'
+            })
+            
+            if 'rows' in groups_response:
+                group_uuids = []
+                for group_name in group_names:
+                    for group in groups_response['rows']:
+                        if group.get('name') == group_name:
+                            group_uuids.append(group.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"Group '{group_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved groups: {dict(zip(group_names, group_uuids))}")
+                
+                return group_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve group names: {str(e)}")
+        
+        return []

--- a/plugins/module_utils/main/haproxy_general.py
+++ b/plugins/module_utils/main/haproxy_general.py
@@ -1,0 +1,191 @@
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import is_unset
+
+
+class HaproxyGeneral:
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        self.m = module
+        self.r = result
+        self.p = module.params
+        
+        self.s = Session(module=module) if session is None else session
+        
+        self.config = {}
+        if 'diff' not in self.r:
+            self.r['diff'] = {'before': {}, 'after': {}}
+
+    def check(self) -> None:
+        """Validate input parameters"""
+        if not is_unset(self.p.get('hard_stop_after')):
+            import re
+            if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['hard_stop_after']):
+                self.m.fail_json(
+                    f"Value of hard_stop_after '{self.p['hard_stop_after']}' is invalid. "
+                    f"Should be a number between 1 and 8 characters, optionally followed by "
+                    f"either 'd', 'h', 'm', 's', 'ms' or 'us'."
+                )
+        
+        if not is_unset(self.p.get('close_spread_time')):
+            import re
+            if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['close_spread_time']):
+                self.m.fail_json(
+                    f"Value of close_spread_time '{self.p['close_spread_time']}' is invalid. "
+                    f"Should be a number between 1 and 8 characters, optionally followed by "
+                    f"either 'd', 'h', 'm', 's', 'ms' or 'us'."
+                )
+
+    def process(self) -> None:
+        """Main process method"""
+        self.run()
+
+    def get_existing(self) -> dict:
+        """Get current configuration and convert to Ansible format"""
+        self.config = self._search_call()
+        return self._api_to_ansible(self.config)
+
+    def _search_call(self) -> dict:
+        """Get current HAProxy configuration"""
+        raw = self.s.get(cnf={
+            'module': 'haproxy',
+            'controller': 'settings',
+            'command': 'get',
+        })
+        
+        if self.m.params.get('debug', False):
+            self.m.warn(f"HAProxy General - RAW RESPONSE: {list(raw.keys()) if raw else 'None'}")
+        
+        return raw.get('haproxy', {}) if raw else {}
+
+    def _api_to_ansible(self, api_config: dict) -> dict:
+        """Convert API config to Ansible format for diff"""
+        ansible_config = {}
+        
+        if self.m.params.get('debug', False):
+            self.m.warn(f"Converting API config with keys: {list(api_config.keys())}")
+        
+        if 'general' in api_config:
+            general = api_config['general']
+            
+            # Boolean fields
+            bool_fields = {
+                'enabled': 'enabled',
+                'gracefulStop': 'graceful_stop',
+                'seamlessReload': 'seamless_reload',
+                'showIntro': 'show_intro',
+            }
+            
+            for api_field, ansible_field in bool_fields.items():
+                if api_field in general:
+                    ansible_config[ansible_field] = general[api_field] == '1'
+            
+            # String fields
+            string_fields = {
+                'hardStopAfter': 'hard_stop_after',
+                'closeSpreadTime': 'close_spread_time',
+            }
+            
+            for api_field, ansible_field in string_fields.items():
+                if api_field in general and general[api_field]:
+                    ansible_config[ansible_field] = general[api_field]
+        
+        return ansible_config
+    
+    def _ansible_to_api(self, ansible_config: dict) -> dict:
+        """Convert Ansible parameters to API format"""
+        api_config = {'haproxy': {'general': {}}}
+        general = api_config['haproxy']['general']
+        
+        field_mapping = {
+            'enabled': 'enabled',
+            'graceful_stop': 'gracefulStop',
+            'hard_stop_after': 'hardStopAfter',
+            'close_spread_time': 'closeSpreadTime',
+            'seamless_reload': 'seamlessReload',
+            'show_intro': 'showIntro',
+        }
+        
+        bool_fields = ['enabled', 'graceful_stop', 'seamless_reload', 'show_intro']
+        
+        for ansible_field, api_field in field_mapping.items():
+            if ansible_field in ansible_config and ansible_config[ansible_field] is not None:
+                value = ansible_config[ansible_field]
+                
+                if ansible_field in bool_fields:
+                    value = '1' if value else '0'
+                
+                general[api_field] = value
+        
+        return api_config
+    
+    def _build_request(self) -> dict:
+        """Build request with correct API structure"""
+        request = {}
+        
+        fields = ['enabled', 'graceful_stop', 'hard_stop_after', 'close_spread_time', 
+                 'seamless_reload', 'show_intro']
+        
+        for field in fields:
+            if field in self.p and self.p[field] is not None:
+                request[field] = self.p[field]
+        
+        return self._ansible_to_api(request)
+    
+    def run(self) -> None:
+        """Main execution method"""
+        self.check()
+        
+        # Get existing configuration
+        existing = self.get_existing()
+        self.r['diff']['before'] = existing.copy()
+        
+        # Check if we're in check mode
+        if self.m.check_mode:
+            after = existing.copy()
+            fields = ['enabled', 'graceful_stop', 'hard_stop_after', 'close_spread_time', 
+                     'seamless_reload', 'show_intro']
+            
+            for field in fields:
+                if field in self.p and self.p[field] is not None:
+                    after[field] = self.p[field]
+            
+            self.r['diff']['after'] = after
+            
+            if existing != after:
+                self.r['changed'] = True
+            
+            return
+        
+        # Build request for API
+        request = self._build_request()
+        
+        # Send update request if there are changes
+        if request.get('haproxy', {}).get('general'):
+            result = self.s.post(cnf={
+                'module': 'haproxy',
+                'controller': 'settings',
+                'command': 'set',
+                'data': request,
+            })
+            
+            if self.m.params.get('debug', False):
+                self.m.warn(f"HAProxy General - SET RESPONSE: '{result}'")
+            
+            # Check if update was successful
+            if result and result.get('result', '') == 'saved':
+                self.r['changed'] = True
+                
+                # Reload service if requested
+                if self.p.get('reload', True):
+                    reload_result = self.s.post(cnf={
+                        'module': 'haproxy',
+                        'controller': 'service',
+                        'command': 'reconfigure',
+                    })
+                    
+                    if self.m.params.get('debug', False):
+                        self.m.warn(f"HAProxy General - RELOAD RESPONSE: '{reload_result}'")
+        
+        # Get new configuration for diff
+        new_config = self.get_existing()
+        self.r['diff']['after'] = new_config

--- a/plugins/module_utils/main/haproxy_group.py
+++ b/plugins/module_utils/main/haproxy_group.py
@@ -1,0 +1,112 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyGroup(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addGroup',
+        'del': 'delGroup',
+        'set': 'setGroup',
+        'search': 'searchGroups',
+        'detail': 'getGroup',
+        'toggle': 'toggleGroup',
+    }
+    API_KEY_PATH = 'group'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'description', 'members', 'add_userlist']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name',
+        'members': 'members',
+        'add_userlist': 'add_userlist'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'group'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.group = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a group!')
+
+        self._base_check()
+
+    def _build_request(self) -> dict:
+        """
+        Override request building to handle user linking.
+        """
+        # Build base request
+        request_data = {}
+        
+        # Handle basic fields
+        for field in ['name', 'description']:
+            if field in self.p and self.p[field] is not None:
+                request_data[field] = self.p[field]
+        
+        # Handle boolean fields
+        for field in ['enabled', 'add_userlist']:
+            if field in self.p:
+                request_data[field] = '1' if self.p[field] else '0'
+        
+        # Handle members - resolve user names to UUIDs
+        # IMPORTANT: Use 'members' (underscore) for UI compatibility, not camelCase
+        if 'members' in self.p and self.p['members']:
+            user_uuids = self._resolve_user_names(self.p['members'])
+            if user_uuids:
+                # Join UUIDs with comma for HAProxy API (same pattern as linkedServers)
+                request_data['members'] = ','.join(user_uuids)
+        
+        return {self.API_KEY_PATH: request_data}
+    
+    def _resolve_user_names(self, user_names: list) -> list:
+        """
+        Resolve user names to UUIDs by fetching the user list.
+        """
+        if not user_names:
+            return []
+        
+        try:
+            # Get all users
+            users_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchUsers'
+            })
+            
+            if 'rows' in users_response:
+                user_uuids = []
+                for user_name in user_names:
+                    for user in users_response['rows']:
+                        if user.get('name') == user_name:
+                            user_uuids.append(user.get('uuid'))
+                            break
+                    else:
+                        self.m.warn(f"User '{user_name}' not found, skipping")
+                
+                if self.p.get('debug', False):
+                    self.m.warn(f"Resolved users: {dict(zip(user_names, user_uuids))}")
+                
+                return user_uuids
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve user names: {str(e)}")
+        
+        return []

--- a/plugins/module_utils/main/haproxy_healthcheck.py
+++ b/plugins/module_utils/main/haproxy_healthcheck.py
@@ -1,0 +1,73 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyHealthcheck(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addHealthcheck',
+        'del': 'delHealthcheck',
+        'set': 'setHealthcheck',
+        'search': 'searchHealthchecks',
+        'detail': 'getHealthcheck',
+        'toggle': 'toggleHealthcheck',
+    }
+    API_KEY_PATH = 'healthcheck'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['description', 'type', 'interval', 'ssl', 'ssl_sni']
+    FIELDS_ALL = ['name', 'description']
+    FIELDS_TRANSLATE = {
+        'description': 'description', 
+        'name': 'name'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'healthcheck'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.healthcheck = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a health check!')
+
+            if is_unset(self.p['type']):
+                self.m.fail_json('You need to provide a type to create a health check!')
+
+            # Validate interval format
+            if not is_unset(self.p['interval']):
+                import re
+                if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['interval']):
+                    self.m.fail_json(
+                        f"Value of interval '{self.p['interval']}' is invalid. "
+                        f"Should be a number between 1 and 8 characters, optionally followed by "
+                        f"either 'd', 'h', 'm', 's', 'ms' or 'us'."
+                    )
+
+        self._base_check()
+
+    def simplify_existing(self, existing: dict) -> dict:
+        """
+        Override simplify_existing to only process fields available from search API.
+        Health Checks API has complex nested structures that need filtering.
+        """
+        simplified = {}
+        available_fields = ['name', 'description', 'uuid']
+        
+        for field in available_fields:
+            if field in existing:
+                simplified[field] = existing[field]
+        
+        return simplified

--- a/plugins/module_utils/main/haproxy_lua.py
+++ b/plugins/module_utils/main/haproxy_lua.py
@@ -1,0 +1,54 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyLua(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addLua',
+        'del': 'delLua',
+        'set': 'setLua',
+        'search': 'searchLuas',
+        'detail': 'getLua',
+        'toggle': 'toggleLua',
+    }
+    API_KEY_PATH = 'lua'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['description', 'enabled', 'content', 'preload', 'filename_scheme']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'name': 'name',
+        'description': 'description',
+        'enabled': 'enabled',
+        'content': 'content',
+        'preload': 'preload',
+        'filename_scheme': 'filename_scheme'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'lua'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.lua = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a Lua script!')
+            
+            if is_unset(self.p['content']):
+                self.m.fail_json('You need to provide content (Lua code) to create a Lua script!')
+
+        self._base_check()

--- a/plugins/module_utils/main/haproxy_mailer.py
+++ b/plugins/module_utils/main/haproxy_mailer.py
@@ -1,0 +1,70 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyMailer(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addMailer',
+        'del': 'delMailer',
+        'set': 'setMailer',
+        'search': 'searchmailers',
+        'detail': 'getMailer',
+        'toggle': 'toggleMailer',
+    }
+    API_KEY_PATH = 'mailer'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'description', 'mailservers', 'sender', 'recipient']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name',
+        'mailservers': 'mailservers',
+        'sender': 'sender',
+        'recipient': 'recipient'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'mailer'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.mailer = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a mailer!')
+
+            if is_unset(self.p['mailservers']):
+                self.m.fail_json('You need to provide mailservers to create a mailer!')
+
+            if is_unset(self.p['sender']):
+                self.m.fail_json('You need to provide a sender email to create a mailer!')
+
+            if is_unset(self.p['recipient']):
+                self.m.fail_json('You need to provide a recipient email to create a mailer!')
+
+            # Basic email validation
+            import re
+            email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+            
+            if not re.match(email_pattern, self.p['sender']):
+                self.m.fail_json(f"Sender '{self.p['sender']}' is not a valid email address!")
+
+            if not re.match(email_pattern, self.p['recipient']):
+                self.m.fail_json(f"Recipient '{self.p['recipient']}' is not a valid email address!")
+
+        self._base_check()

--- a/plugins/module_utils/main/haproxy_maintenance.py
+++ b/plugins/module_utils/main/haproxy_maintenance.py
@@ -1,0 +1,100 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+
+
+class HaproxyMaintenance:
+    """HAProxy maintenance operations class"""
+    
+    API_MOD = 'haproxy'
+    API_CONT = 'maintenance'
+    TIMEOUT = 60.0
+    
+    MAINTENANCE_COMMANDS = {
+        'cert_actions': 'cert_actions',
+        'cert_diff': 'cert_diff', 
+        'cert_sync': 'cert_sync',
+        'cert_sync_bulk': 'cert_sync_bulk',
+        'get': 'get',
+        'search_certificate_diff': 'search_certificate_diff',
+        'search_server': 'search_server',
+        'server_state': 'server_state',
+        'server_state_bulk': 'server_state_bulk',
+        'server_weight': 'server_weight',
+        'server_weight_bulk': 'server_weight_bulk',
+        'fetch_cron_integration': 'fetch_cron_integration',
+        'set': 'set',
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        self.m = module
+        self.r = result
+        self.p = module.params
+        self.s = Session(module=module, timeout=self.TIMEOUT) if session is None else session
+        
+        if 'diff' not in self.r:
+            self.r['diff'] = {'before': {}, 'after': {}}
+
+    def check(self) -> None:
+        """Validate parameters"""
+        if is_unset(self.p['action']):
+            self.m.fail_json('You need to provide an action!')
+        
+        if self.p['action'] not in self.MAINTENANCE_COMMANDS:
+            self.m.fail_json(f'Invalid action: {self.p["action"]}')
+
+    def process(self) -> None:
+        """Execute the maintenance operation"""
+        action = self.p['action']
+        command = self.MAINTENANCE_COMMANDS[action]
+        
+        if self.m.check_mode:
+            self.r['result'] = {'status': 'check_mode', 'action': action}
+            return
+        
+        # Build API call configuration
+        cnf = {
+            'module': self.API_MOD,
+            'controller': self.API_CONT,
+            'command': command,
+        }
+        
+        # Add server parameter for server-specific operations
+        if action in ['search_server', 'server_state', 'server_weight'] and not is_unset(self.p.get('server')):
+            cnf['params'] = [self.p['server']]
+        
+        # Add server state parameter for server state operations
+        if action == 'server_state' and not is_unset(self.p.get('state')):
+            cnf['params'] = cnf.get('params', []) + [self.p['state']]
+        
+        # Add server weight parameter for server weight operations
+        if action == 'server_weight' and not is_unset(self.p.get('weight')):
+            cnf['params'] = cnf.get('params', []) + [str(self.p['weight'])]
+        
+        try:
+            # Use POST for write operations, GET for read operations
+            if action in ['fetch_cron_integration', 'set']:
+                response = self.s.post(cnf=cnf)
+                self.r['changed'] = True
+            else:
+                response = self.s.get(cnf=cnf)
+                self.r['changed'] = False
+            
+            if self.p.get('debug', False):
+                self.m.warn(f"HAProxy Maintenance - {action.upper()} RESPONSE: '{response}'")
+            
+            self.r['result'] = response
+                
+        except Exception as e:
+            self.m.fail_json(f'Maintenance operation {action} failed: {str(e)}')
+        
+        finally:
+            if hasattr(self, 's'):
+                self.s.close()
+
+    def reload(self) -> None:
+        """Not applicable for maintenance operations"""
+        pass

--- a/plugins/module_utils/main/haproxy_mapfile.py
+++ b/plugins/module_utils/main/haproxy_mapfile.py
@@ -1,0 +1,50 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyMapfile(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addMapfile',
+        'del': 'delMapfile',
+        'set': 'setMapfile',
+        'search': 'searchMapfiles',
+        'detail': 'getMapfile',
+        'toggle': 'toggleMapfile',
+    }
+    API_KEY_PATH = 'mapfile'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['description', 'content']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'description': 'description', 
+        'name': 'name',
+        'content': 'content'
+    }
+    FIELDS_TYPING = {}
+    EXIST_ATTR = 'mapfile'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.mapfile = {}
+        self.diff = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a map file!')
+
+            if is_unset(self.p['content']):
+                self.m.fail_json('You need to provide content to create a map file!')
+
+        self._base_check()

--- a/plugins/module_utils/main/haproxy_resolver.py
+++ b/plugins/module_utils/main/haproxy_resolver.py
@@ -1,0 +1,66 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyResolver(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addResolver',
+        'del': 'delResolver',
+        'set': 'setResolver',
+        'search': 'searchresolvers',
+        'detail': 'getResolver',
+        'toggle': 'toggleResolver',
+    }
+    API_KEY_PATH = 'resolver'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'description']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'resolver'
+    TIMEOUT = 60.0
+    
+    INT_VALIDATIONS = {
+        'resolve_retries': {'min': 0, 'max': 100000},
+    }
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.resolver = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a resolver!')
+
+            # Validate timeout format
+            if not is_unset(self.p['timeout_resolve']):
+                import re
+                if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['timeout_resolve']):
+                    self.m.fail_json(
+                        f"Value of timeout_resolve '{self.p['timeout_resolve']}' is invalid. "
+                        f"Should be a number between 1 and 8 characters, optionally followed by "
+                        f"either 'd', 'h', 'm', 's', 'ms' or 'us'."
+                    )
+
+            # Validate that nameservers are provided if not parsing resolv.conf
+            if not self.p['parse_resolv_conf'] and is_unset(self.p['nameservers']):
+                self.m.fail_json('You need to provide nameservers or enable parse_resolv_conf!')
+
+        self._base_check()

--- a/plugins/module_utils/main/haproxy_server.py
+++ b/plugins/module_utils/main/haproxy_server.py
@@ -1,0 +1,181 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_ip, is_valid_domain, is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyServer(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addServer',
+        'del': 'delServer',
+        'set': 'setServer',
+        'search': 'searchServers',
+        'detail': 'getServer',
+        'toggle': 'toggleServer',
+    }
+    API_KEY_PATH = 'server'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'description', 'address', 'port', 'linked_resolver', 'unix_socket']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name',
+        'address': 'address',
+        'port': 'port',
+        'linked_resolver': 'linkedResolver',
+        'unix_socket': 'unix_socket'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled'],
+        'int': ['port']
+    }
+    EXIST_ATTR = 'server'
+    TIMEOUT = 60.0
+    
+    INT_VALIDATIONS = {
+        'port': {'min': 1, 'max': 65535},
+        'weight': {'min': 0, 'max': 255},
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.server = {}
+        self.diff = {}
+
+    def check(self) -> None:
+        # Validate server address
+        if self.p['state'] == 'present':
+            if is_unset(self.p['address']):
+                self.m.fail_json('You need to provide an address to create a server!')
+            
+            if not is_ip(self.p['address']) and \
+                    not is_valid_domain(self.p['address']):
+                self.m.fail_json(
+                    f"Value of address '{self.p['address']}' is neither "
+                    f"a valid IP-Address nor a valid domain-name!"
+                )
+        
+        # Validate source address if provided
+        if not is_unset(self.p['source']):
+            if not is_ip(self.p['source']):
+                self.m.fail_json(
+                    f"Value of source '{self.p['source']}' is not a valid IP-Address!"
+                )
+        
+        # Validate time format for intervals
+        if not is_unset(self.p['check_interval']):
+            import re
+            if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['check_interval']):
+                self.m.fail_json(
+                    f"Value of check_interval '{self.p['check_interval']}' is invalid."
+                )
+        
+        if not is_unset(self.p['check_down_interval']):
+            import re
+            if not re.match(r'^[0-9]{1,8}(?:us|ms|s|m|h|d)?$', self.p['check_down_interval']):
+                self.m.fail_json(
+                    f"Value of check_down_interval '{self.p['check_down_interval']}' is invalid."
+                )
+        
+        self._base_check()
+    
+    def _build_request(self) -> dict:
+        """
+        Override request building to handle relationship field linking.
+        """
+        # Build base request
+        request_data = {}
+        
+        # Handle basic fields
+        for field in ['name', 'description', 'address']:
+            if field in self.p and self.p[field] is not None:
+                request_data[field] = self.p[field]
+        
+        # Handle integer fields
+        for field in ['port']:
+            if field in self.p and self.p[field] is not None:
+                request_data[field] = str(self.p[field])
+        
+        # Handle boolean fields
+        for field in ['enabled']:
+            if field in self.p:
+                request_data[field] = '1' if self.p[field] else '0'
+        
+        # Handle linked resolver - resolve name to UUID
+        if 'linked_resolver' in self.p and self.p['linked_resolver']:
+            resolver_uuid = self._resolve_resolver_name(self.p['linked_resolver'])
+            if resolver_uuid:
+                request_data['linkedResolver'] = resolver_uuid
+        
+        # Handle unix socket - resolve frontend name to UUID
+        if 'unix_socket' in self.p and self.p['unix_socket']:
+            frontend_uuid = self._resolve_frontend_name(self.p['unix_socket'])
+            if frontend_uuid:
+                request_data['unix_socket'] = frontend_uuid
+        
+        return {self.API_KEY_PATH: request_data}
+    
+    def _resolve_resolver_name(self, resolver_name: str) -> str:
+        """
+        Resolve resolver name to UUID by fetching the resolver list.
+        """
+        if not resolver_name:
+            return ''
+        
+        try:
+            resolvers_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchResolvers'
+            })
+            
+            if 'rows' in resolvers_response:
+                for resolver in resolvers_response['rows']:
+                    if resolver.get('name') == resolver_name:
+                        if self.p.get('debug', False):
+                            self.m.warn(f"Resolved resolver '{resolver_name}' to UUID: {resolver.get('uuid')}")
+                        return resolver.get('uuid')
+                
+                self.m.warn(f"Resolver '{resolver_name}' not found")
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve resolver name: {str(e)}")
+        
+        return ''
+    
+    def _resolve_frontend_name(self, frontend_name: str) -> str:
+        """
+        Resolve frontend name to UUID by fetching the frontend list.
+        """
+        if not frontend_name:
+            return ''
+        
+        try:
+            frontends_response = self.s.get(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': 'searchFrontends'
+            })
+            
+            if 'rows' in frontends_response:
+                for frontend in frontends_response['rows']:
+                    if frontend.get('name') == frontend_name:
+                        if self.p.get('debug', False):
+                            self.m.warn(f"Resolved frontend '{frontend_name}' to UUID: {frontend.get('uuid')}")
+                        return frontend.get('uuid')
+                
+                self.m.warn(f"Frontend '{frontend_name}' not found")
+            
+        except Exception as e:
+            self.m.warn(f"Failed to resolve frontend name: {str(e)}")
+        
+        return ''

--- a/plugins/module_utils/main/haproxy_service.py
+++ b/plugins/module_utils/main/haproxy_service.py
@@ -1,0 +1,83 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+
+
+class HaproxyService:
+    """HAProxy service management class"""
+    
+    API_MOD = 'haproxy'
+    API_CONT = 'service'
+    TIMEOUT = 60.0
+    
+    SERVICE_COMMANDS = {
+        'start': 'start',
+        'stop': 'stop',
+        'restart': 'restart',
+        'reload': 'reconfigure',
+        'status': 'status',
+        'configtest': 'configtest',
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        self.m = module
+        self.r = result
+        self.p = module.params
+        self.s = Session(module=module, timeout=self.TIMEOUT) if session is None else session
+        
+        if 'diff' not in self.r:
+            self.r['diff'] = {'before': {}, 'after': {}}
+
+    def check(self) -> None:
+        """Validate parameters"""
+        if is_unset(self.p['action']):
+            self.m.fail_json('You need to provide an action!')
+        
+        if self.p['action'] not in self.SERVICE_COMMANDS:
+            self.m.fail_json(f'Invalid action: {self.p["action"]}')
+
+    def process(self) -> None:
+        """Execute the service operation"""
+        action = self.p['action']
+        command = self.SERVICE_COMMANDS[action]
+        
+        if self.m.check_mode:
+            self.r['result'] = {'status': 'check_mode', 'action': action}
+            return
+        
+        # Perform the service operation
+        try:
+            response = self.s.post(cnf={
+                'module': self.API_MOD,
+                'controller': self.API_CONT,
+                'command': command,
+            })
+            
+            if self.p.get('debug', False):
+                self.m.warn(f"HAProxy Service - {action.upper()} RESPONSE: '{response}'")
+            
+            # Handle different response types
+            if action == 'status':
+                self.r['result'] = response
+            elif action == 'configtest':
+                self.r['result'] = response
+                # Configuration test doesn't change the service state
+                self.r['changed'] = False
+            else:
+                # start, stop, restart, reload operations
+                self.r['result'] = response
+                self.r['changed'] = True
+                
+        except Exception as e:
+            self.m.fail_json(f'Service operation {action} failed: {str(e)}')
+        
+        finally:
+            if hasattr(self, 's'):
+                self.s.close()
+
+    def reload(self) -> None:
+        """Not applicable for service operations"""
+        pass

--- a/plugins/module_utils/main/haproxy_statistics.py
+++ b/plugins/module_utils/main/haproxy_statistics.py
@@ -1,0 +1,73 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+
+
+class HaproxyStatistics:
+    """HAProxy statistics retrieval class"""
+    
+    API_MOD = 'haproxy'
+    API_CONT = 'statistics'
+    TIMEOUT = 30.0
+    
+    STAT_COMMANDS = {
+        'counters': 'counters',
+        'info': 'info',
+        'tables': 'tables',
+    }
+    
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        self.m = module
+        self.r = result
+        self.p = module.params
+        self.s = Session(module=module, timeout=self.TIMEOUT) if session is None else session
+        
+        if 'diff' not in self.r:
+            self.r['diff'] = {'before': {}, 'after': {}}
+
+    def check(self) -> None:
+        """Validate parameters"""
+        if is_unset(self.p['stat_type']):
+            self.m.fail_json('You need to provide a stat_type!')
+        
+        if self.p['stat_type'] not in self.STAT_COMMANDS:
+            self.m.fail_json(f'Invalid stat_type: {self.p["stat_type"]}')
+
+    def process(self) -> None:
+        """Retrieve the statistics"""
+        stat_type = self.p['stat_type']
+        command = self.STAT_COMMANDS[stat_type]
+        
+        # Build API call configuration
+        cnf = {
+            'module': self.API_MOD,
+            'controller': self.API_CONT,
+            'command': command,
+        }
+        
+        # Add table name parameter if specified and stat_type is tables
+        if stat_type == 'tables' and not is_unset(self.p['table_name']):
+            cnf['params'] = [self.p['table_name']]
+        
+        try:
+            response = self.s.get(cnf=cnf)
+            
+            if self.p.get('debug', False):
+                self.m.warn(f"HAProxy Stats - {stat_type.upper()} RESPONSE: '{response}'")
+            
+            self.r['statistics'] = response
+            self.r['changed'] = False  # Statistics retrieval doesn't change anything
+                
+        except Exception as e:
+            self.m.fail_json(f'Statistics retrieval for {stat_type} failed: {str(e)}')
+        
+        finally:
+            if hasattr(self, 's'):
+                self.s.close()
+
+    def reload(self) -> None:
+        """Not applicable for statistics operations"""
+        pass

--- a/plugins/module_utils/main/haproxy_user.py
+++ b/plugins/module_utils/main/haproxy_user.py
@@ -1,0 +1,53 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
+
+
+class HaproxyUser(BaseModule):
+    FIELD_ID = 'name'
+    CMDS = {
+        'add': 'addUser',
+        'del': 'delUser',
+        'set': 'setUser',
+        'search': 'searchUsers',
+        'detail': 'getUser',
+        'toggle': 'toggleUser',
+    }
+    API_KEY_PATH = 'user'
+    API_MOD = 'haproxy'
+    API_CONT = 'settings'
+    API_CONT_REL = 'service'
+    API_CMD_REL = 'reconfigure'
+    FIELDS_CHANGE = ['enabled', 'description', 'password']
+    FIELDS_ALL = ['name']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'enabled': 'enabled',
+        'description': 'description', 
+        'name': 'name',
+        'password': 'password'
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled']
+    }
+    EXIST_ATTR = 'user'
+    TIMEOUT = 60.0
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.user = {}
+        self.diff = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['name']):
+                self.m.fail_json('You need to provide a name to create a user!')
+
+            if is_unset(self.p['password']):
+                self.m.fail_json('You need to provide a password to create a user!')
+
+        self._base_check()

--- a/plugins/modules/haproxy_acl.py
+++ b/plugins/modules/haproxy_acl.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy ACLs on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_acl import HaproxyAcl
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        expression=dict(
+            type='str', required=True,
+            choices=[
+                'http_auth', 'hdr_beg', 'hdr_end', 'hdr', 'hdr_reg', 'hdr_sub',
+                'path_beg', 'path_end', 'path', 'path_reg', 'path_dir', 'path_sub',
+                'cust_hdr_beg', 'cust_hdr_end', 'cust_hdr', 'cust_hdr_reg', 'cust_hdr_sub',
+                'url_param', 'ssl_c_verify', 'ssl_c_verify_code', 'ssl_c_ca_commonname',
+                'ssl_hello_type', 'src', 'src_is_local', 'src_port', 'src_bytes_in_rate',
+                'src_bytes_out_rate', 'src_kbytes_in', 'src_kbytes_out', 'src_conn_cnt',
+                'src_conn_cur', 'src_conn_rate'
+            ]
+        ),
+        value=dict(type='str', required=False),
+        negate=dict(type='bool', required=False, default=False),
+        case_sensitive=dict(type='bool', required=False, default=True),
+        allowedUsers=dict(type='list', elements='str', required=False),
+        allowedGroups=dict(type='list', elements='str', required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyAcl(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_action.py
+++ b/plugins/modules/haproxy_action.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy actions on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_action import HaproxyAction
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        test_type=dict(
+            type='str', required=False, default='if',
+            choices=['if', 'unless']
+        ),
+        linked_acls=dict(type='list', elements='str', required=False),
+        operator=dict(
+            type='str', required=False, default='and',
+            choices=['and', 'or']
+        ),
+        action_type=dict(
+            type='str', required=True,
+            choices=[
+                'use_backend', 'use_server', 'map_use_backend',
+                'http-request_allow', 'http-request_deny', 'http-request_auth',
+                'http-request_redirect', 'http-request_lua', 'http-request_set-header',
+                'http-request_del-header', 'http-request_replace-header',
+                'http-response_allow', 'http-response_deny', 'http-response_set-header',
+                'http-response_del-header', 'http-response_replace-header',
+                'tcp-request_accept', 'tcp-request_reject', 'tcp-request_content_accept',
+                'tcp-request_content_reject', 'tcp-request_connection_accept',
+                'tcp-request_connection_reject',
+                'tcp-response_accept', 'tcp-response_reject', 'tcp-response_content_accept',
+                'tcp-response_content_reject',
+                'fcgi_app', 'fcgi_docroot', 'fcgi_index',
+                'monitor_fail', 'custom'
+            ]
+        ),
+        use_backend=dict(type='str', required=False),
+        use_server=dict(type='list', elements='str', required=False),
+        http_request_auth=dict(type='str', required=False),
+        http_request_redirect=dict(type='str', required=False),
+        http_request_lua=dict(type='str', required=False),
+        custom_lua=dict(type='str', required=False),
+        map_use_backend_file=dict(type='str', required=False),
+        map_use_backend_default=dict(type='str', required=False),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyAction(module, result))
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_backend.py
+++ b/plugins/modules/haproxy_backend.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy backends on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_backend import HaproxyBackend
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        mode=dict(
+            type='str', required=False, default='http',
+            choices=['http', 'tcp']
+        ),
+        algorithm=dict(
+            type='str', required=False, default='roundrobin',
+            choices=['roundrobin', 'static-rr', 'leastconn', 'first', 'source', 'uri', 'random', 'rdp-cookie']
+        ),
+        source=dict(type='str', required=False),
+        health_check_enabled=dict(type='bool', required=False, default=False),
+        health_check=dict(type='str', required=False),
+        health_check_interval=dict(type='str', required=False, default='2s'),
+        health_check_timeout=dict(type='str', required=False, default='2s'),
+        health_check_retries=dict(type='int', required=False, default=3),
+        linked_servers=dict(type='list', elements='str', required=False),
+        linked_actions=dict(type='list', elements='str', required=False),
+        linked_errorfiles=dict(type='list', elements='str', required=False),
+        basic_auth_users=dict(type='list', elements='str', required=False),
+        basic_auth_groups=dict(type='list', elements='str', required=False),
+        linked_resolver=dict(type='str', required=False),
+        http_reuse=dict(
+            type='str', required=False, default='never',
+            choices=['never', 'safe', 'aggressive', 'always']
+        ),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyBackend(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_cpu.py
+++ b/plugins/modules/haproxy_cpu.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy CPUs on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.main import \
+        diff_remove_empty
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_cpu import HaproxyCpu
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    # Generate thread and CPU choices dynamically  
+    thread_choices = ['all', 'odd', 'even'] + [f'x{i}' for i in range(1, 64)]
+    cpu_choices = ['all', 'odd', 'even'] + [f'x{i}' for i in range(0, 64)]
+    
+    module_args = dict(
+        name=dict(type='str', required=True),
+        thread_id=dict(type='str', required=True, choices=thread_choices),
+        cpu_id=dict(type='str', required=True, choices=cpu_choices),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyCpu(module=module, result=result))
+
+    result['diff'] = diff_remove_empty(result['diff'])
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_errorfile.py
+++ b/plugins/modules/haproxy_errorfile.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy error files on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_errorfile import HaproxyErrorfile
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        code=dict(
+            type='str', required=True,
+            choices=['x200', 'x400', 'x403', 'x405', 'x408', 'x429', 'x500', 'x502', 'x503', 'x504']
+        ),
+        content=dict(type='str', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyErrorfile(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_exporter.py
+++ b/plugins/modules/haproxy_exporter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to export HAProxy configuration from OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_exporter import HaproxyExporter
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        export_type=dict(
+            type='str', required=True,
+            choices=['config', 'diff', 'download']
+        ),
+        download_type=dict(type='str', required=False),
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        result={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyExporter(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_fcgi.py
+++ b/plugins/modules/haproxy_fcgi.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy FCGI on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.main import \
+        diff_remove_empty
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_fcgi import HaproxyFcgi
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        docroot=dict(type='str', required=False),
+        index=dict(type='str', required=False, default='index.php'),
+        linked_actions=dict(type='list', elements='str', required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyFcgi(module=module, result=result))
+
+    result['diff'] = diff_remove_empty(result['diff'])
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_frontend.py
+++ b/plugins/modules/haproxy_frontend.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy frontends on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_frontend import HaproxyFrontend
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        bind_address=dict(type='str', required=True),
+        bind_port=dict(type='int', required=True),
+        ssl_enabled=dict(type='bool', required=False, default=False),
+        ssl_certificates=dict(type='list', elements='str', required=False),
+        default_backend=dict(type='str', required=False),
+        linked_actions=dict(type='list', elements='str', required=False),
+        linked_errorfiles=dict(type='list', elements='str', required=False),
+        basic_auth_users=dict(type='list', elements='str', required=False),
+        basic_auth_groups=dict(type='list', elements='str', required=False),
+        mode=dict(
+            type='str', required=False, default='http',
+            choices=['http', 'tcp']
+        ),
+        max_connections=dict(type='int', required=False),
+        log_enabled=dict(type='bool', required=False, default=False),
+        advanced_options=dict(type='str', required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyFrontend(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_general.py
+++ b/plugins/modules/haproxy_general.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy general settings on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_general import HaproxyGeneral
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        graceful_stop=dict(type='bool', required=False, default=False),
+        hard_stop_after=dict(type='str', required=False, default='60s'),
+        close_spread_time=dict(type='str', required=False),
+        seamless_reload=dict(type='bool', required=False, default=False),
+        show_intro=dict(type='bool', required=False, default=True),
+        store_ocsp=dict(type='bool', required=False, default=False),
+        tuning_max_connections=dict(type='int', required=False),
+        tuning_nbthread=dict(type='int', required=False, default=1),
+        tuning_resolvers_prefer=dict(
+            type='str', required=False, default='ipv4',
+            choices=['ipv4', 'ipv6']
+        ),
+        tuning_ssl_server_verify=dict(
+            type='str', required=False, default='ignore',
+            choices=['ignore', 'required']
+        ),
+        tuning_root=dict(type='bool', required=False, default=False),
+        peers_enabled=dict(type='bool', required=False, default=False),
+        peers_name1=dict(type='str', required=False),
+        peers_listen1=dict(type='str', required=False),
+        peers_port1=dict(type='int', required=False, default=1024),
+        peers_name2=dict(type='str', required=False),
+        peers_listen2=dict(type='str', required=False),
+        peers_port2=dict(type='int', required=False, default=1024),
+        # Additional tuning parameters
+        tuning_max_dh_size=dict(type='int', required=False, default=2048),
+        tuning_buffer_size=dict(type='int', required=False, default=16384),
+        tuning_spread_checks=dict(type='int', required=False, default=2),
+        tuning_bogus_proxy_enabled=dict(type='bool', required=False, default=False),
+        tuning_lua_max_mem=dict(type='int', required=False, default=0),
+        tuning_custom_options=dict(type='str', required=False),
+        tuning_ocsp_update_enabled=dict(type='bool', required=False, default=False),
+        tuning_ocsp_update_min_delay=dict(type='int', required=False, default=300),
+        tuning_ocsp_update_max_delay=dict(type='int', required=False, default=3600),
+        tuning_ssl_defaults_enabled=dict(type='bool', required=False, default=False),
+        tuning_ssl_bind_options=dict(type='list', elements='str', required=False),
+        tuning_ssl_min_version=dict(
+            type='str', required=False, default='TLSv1.2',
+            choices=['SSLv3', 'TLSv1.0', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3']
+        ),
+        tuning_ssl_max_version=dict(
+            type='str', required=False,
+            choices=['SSLv3', 'TLSv1.0', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3']
+        ),
+        # Defaults section parameters
+        defaults_max_connections=dict(type='int', required=False),
+        defaults_max_connections_servers=dict(type='int', required=False),
+        defaults_timeout_client=dict(type='str', required=False, default='30s'),
+        defaults_timeout_connect=dict(type='str', required=False, default='30s'),
+        defaults_timeout_check=dict(type='str', required=False),
+        defaults_timeout_server=dict(type='str', required=False, default='30s'),
+        defaults_retries=dict(type='int', required=False, default=3),
+        defaults_redispatch=dict(
+            type='str', required=False, default='x-1',
+            choices=['x3', 'x2', 'x1', 'x0', 'x-1', 'x-2', 'x-3']
+        ),
+        defaults_init_addr=dict(
+            type='list', elements='str', required=False, 
+            default=['last', 'libc']
+        ),
+        defaults_custom_options=dict(type='str', required=False),
+        # Logging section parameters
+        logging_host=dict(type='str', required=False, default='127.0.0.1'),
+        logging_facility=dict(
+            type='str', required=False, default='local0',
+            choices=['alert', 'audit', 'auth2', 'auth', 'cron2', 'cron', 'daemon', 
+                     'ftp', 'kern', 'local0', 'local1', 'local2', 'local3', 'local4',
+                     'local5', 'local6', 'local7', 'lpr', 'mail', 'news', 'ntp',
+                     'syslog', 'user', 'uucp']
+        ),
+        logging_level=dict(
+            type='str', required=False, default='info',
+            choices=['alert', 'crit', 'debug', 'emerg', 'err', 'info', 'notice', 'warning']
+        ),
+        logging_length=dict(type='int', required=False),
+        # Stats section parameters
+        stats_enabled=dict(type='bool', required=False, default=False),
+        stats_port=dict(type='int', required=False, default=8822),
+        stats_remote_enabled=dict(type='bool', required=False, default=False),
+        stats_remote_bind=dict(type='list', elements='str', required=False),
+        stats_auth_enabled=dict(type='bool', required=False, default=False),
+        stats_users=dict(type='list', elements='str', required=False),
+        stats_custom_options=dict(type='str', required=False),
+        stats_prometheus_enabled=dict(type='bool', required=False, default=False),
+        stats_prometheus_bind=dict(
+            type='list', elements='str', required=False, 
+            default=['*:8404']
+        ),
+        stats_prometheus_path=dict(type='str', required=False, default='/metrics'),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    # Create and run HAProxy general configuration handler
+    handler = HaproxyGeneral(module=module, result=result)
+    
+    try:
+        handler.process()
+    except Exception as e:
+        module.fail_json(msg=f"HAProxy general configuration failed: {str(e)}")
+    
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_group.py
+++ b/plugins/modules/haproxy_group.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy groups on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_group import HaproxyGroup
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        members=dict(type='list', elements='str', required=False),
+        add_userlist=dict(type='bool', required=False, default=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyGroup(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_healthcheck.py
+++ b/plugins/modules/haproxy_healthcheck.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy health checks on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_healthcheck import HaproxyHealthcheck
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        type=dict(
+            type='str', required=False, default='http',
+            choices=['tcp', 'http', 'agent', 'ldap', 'mysql', 'pgsql', 'redis', 'smtp', 'esmtp', 'ssl']
+        ),
+        interval=dict(type='str', required=False, default='2s'),
+        ssl=dict(
+            type='str', required=False, default='nopref',
+            choices=['nopref', 'ssl', 'sslsni', 'nossl']
+        ),
+        ssl_sni=dict(type='str', required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyHealthcheck(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_lua.py
+++ b/plugins/modules/haproxy_lua.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python3
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy LUA scripts on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.main import \
+        diff_remove_empty
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_lua import HaproxyLua
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        preload=dict(type='bool', required=False, default=True),
+        filename_scheme=dict(
+            type='str', required=False, default='id',
+            choices=['id', 'name']
+        ),
+        content=dict(type='str', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyLua(module=module, result=result))
+
+    result['diff'] = diff_remove_empty(result['diff'])
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_mailer.py
+++ b/plugins/modules/haproxy_mailer.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy mailers on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_mailer import HaproxyMailer
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        mailservers=dict(type='list', elements='str', required=True),
+        sender=dict(type='str', required=True),
+        recipient=dict(type='str', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyMailer(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_maintenance.py
+++ b/plugins/modules/haproxy_maintenance.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to perform HAProxy maintenance operations on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_maintenance import HaproxyMaintenance
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        action=dict(
+            type='str', required=True,
+            choices=[
+                'cert_actions', 'cert_diff', 'cert_sync', 'cert_sync_bulk',
+                'get', 'search_certificate_diff', 'search_server',
+                'server_state', 'server_state_bulk', 'server_weight', 
+                'server_weight_bulk', 'fetch_cron_integration', 'set'
+            ]
+        ),
+        server=dict(type='str', required=False),
+        state=dict(
+            type='str', required=False,
+            choices=['ready', 'drain', 'maint']
+        ),
+        weight=dict(type='int', required=False),
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        result={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyMaintenance(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_mapfile.py
+++ b/plugins/modules/haproxy_mapfile.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy map files on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_mapfile import HaproxyMapfile
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        content=dict(type='str', required=True),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyMapfile(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_resolver.py
+++ b/plugins/modules/haproxy_resolver.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy resolvers on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_resolver import HaproxyResolver
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        nameservers=dict(type='list', elements='str', required=False),
+        parse_resolv_conf=dict(type='bool', required=False, default=False),
+        resolve_retries=dict(type='int', required=False, default=3),
+        timeout_resolve=dict(type='str', required=False, default='1s'),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyResolver(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_server.py
+++ b/plugins/modules/haproxy_server.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy servers on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_server import HaproxyServer
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        address=dict(type='str', required=True),
+        port=dict(type='int', required=True),
+        ssl=dict(type='bool', required=False, default=False),
+        ssl_ca=dict(type='str', required=False),
+        weight=dict(type='int', required=False, default=1),
+        check_interval=dict(type='str', required=False, default='2s'),
+        check_down_interval=dict(type='str', required=False),
+        source=dict(type='str', required=False),
+        linked_resolver=dict(type='str', required=False),
+        unix_socket=dict(type='str', required=False),
+        advanced=dict(type='str', required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyServer(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_service.py
+++ b/plugins/modules/haproxy_service.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to manage HAProxy service operations on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_service import HaproxyService
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        action=dict(
+            type='str', required=True,
+            choices=['start', 'stop', 'restart', 'reload', 'status', 'configtest']
+        ),
+        wait_for_result=dict(type='bool', required=False, default=True),
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        result={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyService(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_statistics.py
+++ b/plugins/modules/haproxy_statistics.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to retrieve HAProxy statistics from OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_statistics import HaproxyStatistics
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        stat_type=dict(
+            type='str', required=True,
+            choices=['counters', 'info', 'tables']
+        ),
+        table_name=dict(type='str', required=False),
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        statistics={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyStatistics(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/haproxy_user.py
+++ b/plugins/modules/haproxy_user.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Copyright: (C) 2025, MaximeWewer
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Module to configure HAProxy users on OPNsense"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.wrapper import module_wrapper
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, EN_ONLY_MOD_ARG
+    from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_user import HaproxyUser
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+# EXAMPLES = 'https://opnsense.ansibleguy.net/en/latest/modules/haproxy.html'
+
+
+def run_module():
+    """Initiate module execution"""
+    module_args = dict(
+        name=dict(type='str', required=True),
+        description=dict(type='str', required=False),
+        password=dict(type='str', required=True, no_log=True),
+        groups=dict(type='list', elements='str', required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        **EN_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(HaproxyUser(module=module, result=result))
+
+    module.exit_json(**result)
+
+
+def main():
+    """Module entry point"""
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/list.py
+++ b/plugins/modules/list.py
@@ -40,6 +40,10 @@ TARGETS = [
     'acme_validation', 'acme_action', 'acme_certificate', 'postfix_general', 'postfix_domain', 'postfix_recipient',
     'postfix_recipientbcc', 'postfix_sender', 'postfix_senderbcc', 'postfix_sendercanonical', 'postfix_headercheck',
     'postfix_address', 'dhcp_subnet', 'dhcp_general', 'interface_gre', 'nat_one_to_one', 'nat_source',
+    'haproxy_general', 'haproxy_backend', 'haproxy_server', 'haproxy_frontend', 'haproxy_service', 'haproxy_statistics',
+    'haproxy_maintenance', 'haproxy_exporter', 'haproxy_acl', 'haproxy_user', 'haproxy_group', 'haproxy_errorfile',
+    'haproxy_healthcheck', 'haproxy_mapfile', 'haproxy_resolver', 'haproxy_mailer', 'haproxy_action', 'haproxy_lua',
+    'haproxy_fcgi', 'haproxy_cpu',
     'ipsec_manual_spd', 'hasync_general', 'snapshot', 'frr_bgp_redistribution', 'frr_ospf_redistribution',
     'frr_ospf3_redistribution', 'frr_ospf3_route_map', 'frr_ospf3_prefix_list', 'frr_ospf3_network',
     'frr_bgp_peer_group',
@@ -508,6 +512,86 @@ def run_module():
         elif target == 'postfix_address':
             from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.postfix_address import \
                 Address as Target_Obj
+
+        elif target == 'haproxy_general':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_general import \
+                HaproxyGeneral as Target_Obj
+
+        elif target == 'haproxy_backend':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_backend import \
+                HaproxyBackend as Target_Obj
+
+        elif target == 'haproxy_server':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_server import \
+                HaproxyServer as Target_Obj
+
+        elif target == 'haproxy_frontend':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_frontend import \
+                HaproxyFrontend as Target_Obj
+
+        elif target == 'haproxy_service':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_service import \
+                HaproxyService as Target_Obj
+
+        elif target == 'haproxy_statistics':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_statistics import \
+                HaproxyStatistics as Target_Obj
+
+        elif target == 'haproxy_maintenance':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_maintenance import \
+                HaproxyMaintenance as Target_Obj
+
+        elif target == 'haproxy_exporter':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_exporter import \
+                HaproxyExporter as Target_Obj
+
+        elif target == 'haproxy_acl':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_acl import \
+                HaproxyAcl as Target_Obj
+
+        elif target == 'haproxy_user':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_user import \
+                HaproxyUser as Target_Obj
+
+        elif target == 'haproxy_group':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_group import \
+                HaproxyGroup as Target_Obj
+
+        elif target == 'haproxy_errorfile':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_errorfile import \
+                HaproxyErrorfile as Target_Obj
+
+        elif target == 'haproxy_healthcheck':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_healthcheck import \
+                HaproxyHealthcheck as Target_Obj
+
+        elif target == 'haproxy_mapfile':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_mapfile import \
+                HaproxyMapfile as Target_Obj
+
+        elif target == 'haproxy_resolver':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_resolver import \
+                HaproxyResolver as Target_Obj
+
+        elif target == 'haproxy_mailer':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_mailer import \
+                HaproxyMailer as Target_Obj
+
+        elif target == 'haproxy_action':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_action import \
+                HaproxyAction as Target_Obj
+
+        elif target == 'haproxy_lua':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_lua import \
+                HaproxyLua as Target_Obj
+
+        elif target == 'haproxy_fcgi':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_fcgi import \
+                HaproxyFcgi as Target_Obj
+
+        elif target == 'haproxy_cpu':
+            from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.haproxy_cpu import \
+                HaproxyCpu as Target_Obj
 
         elif target == 'hasync_general':
             from ansible_collections.ansibleguy.opnsense.plugins.module_utils.main.hasync_general import \

--- a/plugins/modules/reload.py
+++ b/plugins/modules/reload.py
@@ -51,6 +51,7 @@ def run_module():
                 'openvpn',
                 'dhcrelay',
                 'dhcp', 'kea',
+                'haproxy',
             ],
             description='What part of the running config should be reloaded'
         ),

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -209,6 +209,26 @@ run_test_soft 'postfix_headercheck' 1
 run_test_soft 'postfix_address' 1
 run_test_soft 'hasync_general' 1
 run_test_soft 'hasync_service' 0 # check mode => dependency on hasync_general
+run_test_soft 'haproxy_general' 1
+run_test_soft 'haproxy_service' 1
+run_test_soft 'haproxy_backend' 1
+run_test_soft 'haproxy_frontend' 1
+run_test_soft 'haproxy_server' 1
+run_test_soft 'haproxy_statistics' 1
+run_test_soft 'haproxy_maintenance' 1
+run_test_soft 'haproxy_exporter' 1
+run_test_soft 'haproxy_acl' 1
+run_test_soft 'haproxy_user' 1
+run_test_soft 'haproxy_group' 1
+run_test_soft 'haproxy_errorfile' 1
+run_test_soft 'haproxy_healthcheck' 1
+run_test_soft 'haproxy_mapfile' 1
+run_test_soft 'haproxy_resolver' 1
+run_test_soft 'haproxy_mailer' 1
+run_test_soft 'haproxy_action' 1
+run_test_soft 'haproxy_lua' 1
+run_test_soft 'haproxy_fcgi' 1
+run_test_soft 'haproxy_cpu' 1
 run_test_soft 'snapshot' 1
 run_test_soft 'raw' 1
 

--- a/tests/1_cleanup.yml
+++ b/tests/1_cleanup.yml
@@ -922,3 +922,163 @@
       failed_when:
         - cl_snap2.failed
         - "'Unsupported' not in cl_snap2.msg | default('')"
+
+    - name: Cleanup HAProxy backends
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_1'
+        - 'ANSIBLE_TEST_BACKEND_2'
+
+    - name: Cleanup HAProxy servers
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_1'
+        - 'ANSIBLE_TEST_SERVER_2'
+
+    - name: Cleanup HAProxy frontends
+      ansibleguy.opnsense.haproxy_frontend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_FRONTEND_1'
+        - 'ANSIBLE_TEST_FRONTEND_2'
+
+    - name: Cleanup HAProxy actions
+      ansibleguy.opnsense.haproxy_action:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'test_use_backend'
+        - 'test_http_allow'
+        - 'test_http_deny'
+        - 'test_custom'
+
+    - name: Cleanup HAProxy Lua scripts
+      ansibleguy.opnsense.haproxy_lua:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'test_auth_lua'
+        - 'test_logger_lua'
+        - 'test_custom_lua'
+
+    - name: Cleanup HAProxy FCGI apps
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'test_php_app'
+        - 'test_wordpress'
+        - 'test_custom_app'
+
+    - name: Cleanup HAProxy CPU affinity rules
+      ansibleguy.opnsense.haproxy_cpu:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'test_thread1_cpu0'
+        - 'test_odd_threads'
+        - 'test_even_threads'
+        - 'test_all_threads'
+
+    - name: Cleanup HAProxy ACLs
+      ansibleguy.opnsense.haproxy_acl:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_ACL'
+        - 'ANSIBLE_TEST_2_ACL'
+        - 'ANSIBLE_TEST_3_ACL'
+        - 'ANSIBLE_TEST_AUTH_ACL'
+        - 'ANSIBLE_TEST_ACL_GROUP_1'
+        - 'ANSIBLE_TEST_ACL_GROUP_2'
+        - 'ANSIBLE_TEST_ACL_USER_1'
+        - 'ANSIBLE_TEST_ACL_USER_2'
+
+    - name: Cleanup HAProxy users
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_USER'
+        - 'ANSIBLE_TEST_2_USER'
+        - 'ANSIBLE_TEST_USER_1'
+        - 'ANSIBLE_TEST_USER_2'
+        - 'ANSIBLE_TEST_USER_3'
+        - 'ANSIBLE_TEST_ACL_USER_1'
+        - 'ANSIBLE_TEST_ACL_USER_2'
+
+    - name: Cleanup HAProxy groups
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_GROUP'
+        - 'ANSIBLE_TEST_2_GROUP'
+        - 'ANSIBLE_TEST_3_GROUP'
+        - 'ANSIBLE_TEST_ACL_GROUP_1'
+        - 'ANSIBLE_TEST_ACL_GROUP_2'
+
+    - name: Cleanup HAProxy errorfiles
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ERROR_1'
+        - 'ANSIBLE_TEST_ERROR_2'
+        - 'test_400_error'
+        - 'test_403_error'
+        - 'fe_error_1'
+        - 'fe_error_2'
+
+    - name: Cleanup HAProxy healthchecks
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_HEALTHCHECK_1'
+        - 'ANSIBLE_TEST_HEALTHCHECK_2'
+
+    - name: Cleanup HAProxy mapfiles
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_MAPFILE_1'
+        - 'ANSIBLE_TEST_MAPFILE_2'
+
+    - name: Cleanup HAProxy resolvers
+      ansibleguy.opnsense.haproxy_resolver:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_RESOLVER_1'
+        - 'ANSIBLE_TEST_RESOLVER_2'
+
+    - name: Cleanup HAProxy mailers
+      ansibleguy.opnsense.haproxy_mailer:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_MAILER_1'
+        - 'ANSIBLE_TEST_MAILER_2'
+
+    - name: Cleanup HAProxy statistics
+      ansibleguy.opnsense.haproxy_statistics:
+        enabled: false
+
+    - name: Cleanup HAProxy maintenance mode
+      ansibleguy.opnsense.haproxy_maintenance:
+        enabled: false
+
+    - name: Cleanup HAProxy exporter
+      ansibleguy.opnsense.haproxy_exporter:
+        enabled: false
+
+    - name: Reset HAProxy general settings
+      ansibleguy.opnsense.haproxy_general:
+        enabled: false

--- a/tests/haproxy_acl.yml
+++ b/tests/haproxy_acl.yml
@@ -1,0 +1,192 @@
+---
+
+- name: Testing HAProxy ACLs
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_acl'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+  - name: List existing ACLs
+    ansibleguy.opnsense.list:
+    register: existing_entries
+
+  - name: Clean up test ACLs, groups, and users (before)
+    ansibleguy.opnsense.haproxy_acl:
+      name: "{{ item }}"
+      state: 'absent'
+    loop:
+    - 'ANSIBLE_TEST_1_ACL'
+    - 'ANSIBLE_TEST_2_ACL'
+    - 'ANSIBLE_TEST_3_ACL'
+    - 'ANSIBLE_TEST_AUTH_ACL'
+
+  - name: Clean up test groups (before)
+    ansibleguy.opnsense.haproxy_group:
+      name: "{{ item }}"
+      state: 'absent'
+    loop:
+    - 'ANSIBLE_TEST_ACL_GROUP_1'
+    - 'ANSIBLE_TEST_ACL_GROUP_2'
+
+  - name: Clean up test users (before)
+    ansibleguy.opnsense.haproxy_user:
+      name: "{{ item }}"
+      state: 'absent'
+    loop:
+    - 'ANSIBLE_TEST_ACL_USER_1'
+    - 'ANSIBLE_TEST_ACL_USER_2'
+
+  - name: Create test users for ACL testing
+    ansibleguy.opnsense.haproxy_user:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      password: "{{ item.password }}"
+      enabled: true
+    loop:
+    - { name: 'ANSIBLE_TEST_ACL_USER_1', desc: 'ACL test user 1', password: 'aclpass1' }
+    - { name: 'ANSIBLE_TEST_ACL_USER_2', desc: 'ACL test user 2', password: 'aclpass2' }
+
+  - name: Create test groups for ACL testing
+    ansibleguy.opnsense.haproxy_group:
+      name: "{{ item.name }}"
+      description: "{{ item.desc }}"
+      enabled: true
+      add_userlist: true
+      members: "{{ item.members }}"
+    loop:
+    - { name: 'ANSIBLE_TEST_ACL_GROUP_1', desc: 'ACL test group 1', members: ['ANSIBLE_TEST_ACL_USER_1'] }
+    - { name: 'ANSIBLE_TEST_ACL_GROUP_2', desc: 'ACL test group 2', members: ['ANSIBLE_TEST_ACL_USER_2'] }
+
+  - name: Add host ACL (check)
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_1_ACL'
+      description: 'Test host ACL'
+      expression: 'hdr'
+      value: 'api.example.com'
+    check_mode: true
+    register: opn_acl1_check
+
+  - name: Add host ACL
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_1_ACL'
+      description: 'Test host ACL'
+      expression: 'hdr'
+      value: 'api.example.com'
+    register: opn_acl1
+
+  - name: Verify ACL creation
+    ansibleguy.opnsense.list:
+    register: opn_acl1_verify
+
+  - name: Add path ACL
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_2_ACL'
+      description: 'Test path ACL'
+      expression: 'path_beg'
+      value: '/admin'
+      negate: false
+      case_sensitive: true
+    register: opn_acl2
+
+  - name: Add source IP ACL
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_3_ACL'
+      description: 'Test source IP ACL'
+      expression: 'src'
+      value: '192.168.1.0/24'
+    register: opn_acl3
+
+  - name: Modify ACL 1
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_1_ACL'
+      description: 'Modified test host ACL'
+      expression: 'hdr_beg'
+      value: 'api.'
+    register: opn_acl1_changed
+
+  - name: ACL 1 should not change (2)
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_1_ACL'
+      description: 'Modified test host ACL'
+      expression: 'hdr_beg'
+      value: 'api.'
+    register: opn_acl1_changed2
+
+  - name: Add HTTP auth ACL with name-based user and group linking
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_AUTH_ACL'
+      description: 'Test HTTP auth ACL with name-based linking'
+      expression: 'http_auth'
+      allowedUsers: ['ANSIBLE_TEST_ACL_USER_1']  # Test name-based user linking
+      allowedGroups: ['ANSIBLE_TEST_ACL_GROUP_1', 'ANSIBLE_TEST_ACL_GROUP_2']  # Test name-based group linking
+    register: opn_acl_auth
+
+  - name: Update auth ACL users and groups
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_AUTH_ACL'
+      allowedUsers: ['ANSIBLE_TEST_ACL_USER_1', 'ANSIBLE_TEST_ACL_USER_2']  # Add second user
+      allowedGroups: ['ANSIBLE_TEST_ACL_GROUP_2']  # Remove first group
+    register: opn_acl_auth_changed
+
+  - name: Disable ACL 3
+    ansibleguy.opnsense.haproxy_acl:
+      name: 'ANSIBLE_TEST_3_ACL'
+      enabled: false
+    register: opn_acl3_disabled
+
+  - name: Clean up test ACLs (after)
+    ansibleguy.opnsense.haproxy_acl:
+      name: "{{ item }}"
+      state: 'absent'
+    loop:
+    - 'ANSIBLE_TEST_1_ACL'
+    - 'ANSIBLE_TEST_2_ACL'
+    - 'ANSIBLE_TEST_3_ACL'
+    - 'ANSIBLE_TEST_AUTH_ACL'
+
+  - name: Clean up test groups (after)
+    ansibleguy.opnsense.haproxy_group:
+      name: "{{ item }}"
+      state: 'absent'
+    loop:
+    - 'ANSIBLE_TEST_ACL_GROUP_1'
+    - 'ANSIBLE_TEST_ACL_GROUP_2'
+
+  - name: Clean up test users (after)
+    ansibleguy.opnsense.haproxy_user:
+      name: "{{ item }}"
+      state: 'absent'
+    loop:
+    - 'ANSIBLE_TEST_ACL_USER_1'
+    - 'ANSIBLE_TEST_ACL_USER_2'
+
+  - name: Verify cleanup
+    ansibleguy.opnsense.list:
+    register: opn_cleanup_verify
+
+  - name: Show test results
+    ansible.builtin.assert:
+      that:
+      - opn_acl1_check is changed
+      - opn_acl1 is changed
+      - opn_acl2 is changed
+      - opn_acl3 is changed
+      - opn_acl1_changed is changed
+      - opn_acl1_changed2 is not changed
+      - opn_acl_auth is changed
+      - opn_acl_auth_changed is changed
+      - opn_acl3_disabled is changed
+      - "opn_acl1_verify.data | length == (existing_entries.data | length + 1)"
+      - "'ANSIBLE_TEST_1_ACL' in opn_acl1_verify.data | map(attribute='name')"
+      - "'ANSIBLE_TEST_1_ACL' not in opn_cleanup_verify.data | map(attribute='name')"
+      msg: 'HAProxy ACL tests failed! Name-based user/group linking may not be working correctly.'

--- a/tests/haproxy_action.yml
+++ b/tests/haproxy_action.yml
@@ -1,0 +1,312 @@
+---
+
+- name: Testing HAProxy Actions with Name-Based Linking
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_action'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing actions
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    # ===== CLEANUP BEFORE TESTS =====
+    - name: Clean up test actions (before)
+      ansibleguy.opnsense.haproxy_action:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ACTION_USE_BACKEND'
+        - 'ANSIBLE_TEST_ACTION_USE_SERVER'
+        - 'ANSIBLE_TEST_ACTION_LINKED_ACLS'
+        - 'ANSIBLE_TEST_ACTION_MAP_BACKEND'
+        - 'ANSIBLE_TEST_ACTION_COMPLEX'
+        - 'ANSIBLE_TEST_ACTION_BASIC'
+
+    - name: Clean up test ACLs (before)
+      ansibleguy.opnsense.haproxy_acl:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ACL_HOST'
+        - 'ANSIBLE_TEST_ACL_PATH'
+        - 'ANSIBLE_TEST_ACL_IP'
+
+    - name: Clean up test backends (before)
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_WEB'
+        - 'ANSIBLE_TEST_BACKEND_API' 
+        - 'ANSIBLE_TEST_BACKEND_DEFAULT'
+
+    - name: Clean up test servers (before)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_WEB1'
+        - 'ANSIBLE_TEST_SERVER_WEB2'
+        - 'ANSIBLE_TEST_SERVER_API1'
+
+    # ===== CREATE PREREQUISITE RESOURCES =====
+    - name: Create test ACLs for linking
+      ansibleguy.opnsense.haproxy_acl:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        expression: "{{ item.expression }}"
+        value: "{{ item.value }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_ACL_HOST', desc: 'Test host ACL for actions', expression: 'hdr', value: 'api.example.com' }
+        - { name: 'ANSIBLE_TEST_ACL_PATH', desc: 'Test path ACL for actions', expression: 'path_beg', value: '/admin' }
+        - { name: 'ANSIBLE_TEST_ACL_IP', desc: 'Test IP ACL for actions', expression: 'src', value: '192.168.1.0/24' }
+
+    - name: Create test backends for linking
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        mode: "{{ item.mode }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_BACKEND_WEB', desc: 'Test web backend for actions', mode: 'http' }
+        - { name: 'ANSIBLE_TEST_BACKEND_API', desc: 'Test API backend for actions', mode: 'http' }
+        - { name: 'ANSIBLE_TEST_BACKEND_DEFAULT', desc: 'Test default backend for actions', mode: 'http' }
+
+    - name: Create test servers for linking
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        address: "{{ item.address }}"
+        port: "{{ item.port }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_SERVER_WEB1', desc: 'Test web server 1 for actions', address: '192.168.1.10', port: '80' }
+        - { name: 'ANSIBLE_TEST_SERVER_WEB2', desc: 'Test web server 2 for actions', address: '192.168.1.11', port: '80' }
+        - { name: 'ANSIBLE_TEST_SERVER_API1', desc: 'Test API server 1 for actions', address: '192.168.1.20', port: '8080' }
+
+    # ===== TEST NAME-BASED LINKING FUNCTIONALITY =====
+
+    # Test 1: Create action with use_backend linking
+    - name: Add action with use_backend name-based linking (check)
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_USE_BACKEND'
+        description: 'Test action with use_backend linking'
+        test_type: 'if'
+        action_type: 'use_backend'
+        use_backend: 'ANSIBLE_TEST_BACKEND_WEB'  # Test name-based backend linking
+      check_mode: true
+      register: action_use_backend_check
+
+    - name: Add action with use_backend name-based linking
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_USE_BACKEND'
+        description: 'Test action with use_backend linking'
+        test_type: 'if'
+        action_type: 'use_backend'
+        use_backend: 'ANSIBLE_TEST_BACKEND_WEB'  # Test name-based backend linking
+      register: action_use_backend
+
+    # Test 2: Create action with use_server linking
+    - name: Add action with use_server name-based linking
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_USE_SERVER'
+        description: 'Test action with use_server linking'
+        test_type: 'if'
+        action_type: 'use_server'
+        use_server: ['ANSIBLE_TEST_SERVER_WEB1', 'ANSIBLE_TEST_SERVER_WEB2']  # Test name-based server linking
+      register: action_use_server
+
+    # Test 3: Create action with linked_acls
+    - name: Add action with linked_acls name-based linking
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_LINKED_ACLS'
+        description: 'Test action with linked ACLs'
+        test_type: 'if'
+        action_type: 'http-request_allow'
+        linked_acls: ['ANSIBLE_TEST_ACL_HOST', 'ANSIBLE_TEST_ACL_PATH']  # Test name-based ACL linking
+      register: action_linked_acls
+
+    # Test 4: Create action with map_use_backend_default
+    - name: Add action with map_use_backend_default name-based linking
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_MAP_BACKEND'
+        description: 'Test action with map backend default'
+        test_type: 'if'
+        action_type: 'map_use_backend'
+        map_use_backend_default: 'ANSIBLE_TEST_BACKEND_DEFAULT'  # Test name-based default backend linking
+      register: action_map_backend
+
+    # Test 5: Create complex action with multiple linkings
+    - name: Add complex action with multiple name-based linkings
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_COMPLEX'
+        description: 'Test action with multiple linkings'
+        test_type: 'if'
+        action_type: 'use_backend'
+        linked_acls: ['ANSIBLE_TEST_ACL_HOST', 'ANSIBLE_TEST_ACL_IP']  # Multiple ACLs
+        use_backend: 'ANSIBLE_TEST_BACKEND_API'  # Backend linking
+      register: action_complex
+
+    # Test 6: Basic action without linkings for comparison
+    - name: Add basic action without linkings
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_BASIC'
+        description: 'Basic test action without linkings'
+        test_type: 'unless'
+        action_type: 'http-request_deny'
+      register: action_basic
+
+    # ===== TEST UPDATING LINKAGES =====
+
+    # Test 7: Update use_backend action to use different backend
+    - name: Update use_backend action with different backend
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_USE_BACKEND'
+        use_backend: 'ANSIBLE_TEST_BACKEND_API'  # Change from WEB to API backend
+      register: action_use_backend_updated
+
+    # Test 8: Update use_server action - add/remove servers
+    - name: Update use_server action with different servers
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_USE_SERVER'
+        use_server: ['ANSIBLE_TEST_SERVER_WEB2', 'ANSIBLE_TEST_SERVER_API1']  # Remove WEB1, add API1
+      register: action_use_server_updated
+
+    # Test 9: Update linked_acls - add and remove ACLs
+    - name: Update linked_acls action with different ACLs
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_LINKED_ACLS'
+        linked_acls: ['ANSIBLE_TEST_ACL_PATH', 'ANSIBLE_TEST_ACL_IP']  # Remove HOST, add IP
+      register: action_linked_acls_updated
+
+    # Test 10: Update map_use_backend_default
+    - name: Update map_use_backend_default with different backend
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_MAP_BACKEND'
+        map_use_backend_default: 'ANSIBLE_TEST_BACKEND_WEB'  # Change from DEFAULT to WEB
+      register: action_map_backend_updated
+
+    # ===== TEST IDEMPOTENCY =====
+
+    # Test 11: Verify idempotency - re-run same configuration
+    - name: Test idempotency for use_backend action
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_USE_BACKEND'
+        description: 'Test action with use_backend linking'
+        test_type: 'if'
+        action_type: 'use_backend'
+        use_backend: 'ANSIBLE_TEST_BACKEND_API'  # Same as last update
+      register: action_use_backend_idempotent
+
+    - name: Test idempotency for complex action
+      ansibleguy.opnsense.haproxy_action:
+        name: 'ANSIBLE_TEST_ACTION_COMPLEX'
+        description: 'Test action with multiple linkings'
+        test_type: 'if'
+        action_type: 'use_backend'
+        linked_acls: ['ANSIBLE_TEST_ACL_HOST', 'ANSIBLE_TEST_ACL_IP']
+        use_backend: 'ANSIBLE_TEST_BACKEND_API'
+      register: action_complex_idempotent
+
+    # ===== VERIFY CREATION =====
+    - name: Verify action creation
+      ansibleguy.opnsense.list:
+      register: actions_verify
+
+    # ===== CLEANUP AFTER TESTS =====
+    - name: Clean up test actions (after)
+      ansibleguy.opnsense.haproxy_action:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ACTION_USE_BACKEND'
+        - 'ANSIBLE_TEST_ACTION_USE_SERVER'
+        - 'ANSIBLE_TEST_ACTION_LINKED_ACLS'
+        - 'ANSIBLE_TEST_ACTION_MAP_BACKEND'
+        - 'ANSIBLE_TEST_ACTION_COMPLEX'
+        - 'ANSIBLE_TEST_ACTION_BASIC'
+
+    - name: Clean up test ACLs (after)
+      ansibleguy.opnsense.haproxy_acl:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ACL_HOST'
+        - 'ANSIBLE_TEST_ACL_PATH'
+        - 'ANSIBLE_TEST_ACL_IP'
+
+    - name: Clean up test backends (after)
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_WEB'
+        - 'ANSIBLE_TEST_BACKEND_API'
+        - 'ANSIBLE_TEST_BACKEND_DEFAULT'
+
+    - name: Clean up test servers (after)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_WEB1'
+        - 'ANSIBLE_TEST_SERVER_WEB2'
+        - 'ANSIBLE_TEST_SERVER_API1'
+
+    # ===== VERIFY CLEANUP =====
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: cleanup_verify
+
+    # ===== ASSERTIONS =====
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          # Check mode and basic creation tests
+          - action_use_backend_check is changed
+          - action_use_backend is changed
+          - action_use_server is changed
+          - action_linked_acls is changed
+          - action_map_backend is changed
+          - action_complex is changed
+          - action_basic is changed
+          
+          # Update tests - should detect changes
+          - action_use_backend_updated is changed
+          - action_use_server_updated is changed
+          - action_linked_acls_updated is changed
+          - action_map_backend_updated is changed
+          
+          # Idempotency tests - should not detect changes
+          - action_use_backend_idempotent is not changed
+          - action_complex_idempotent is not changed
+          
+          # Verify action was created
+          - "actions_verify.data | length == (existing_entries.data | length + 6)"
+          - "'ANSIBLE_TEST_ACTION_USE_BACKEND' in actions_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_USE_SERVER' in actions_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_LINKED_ACLS' in actions_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_MAP_BACKEND' in actions_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_COMPLEX' in actions_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_BASIC' in actions_verify.data | map(attribute='name')"
+          
+          # Verify cleanup worked
+          - "'ANSIBLE_TEST_ACTION_USE_BACKEND' not in cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_USE_SERVER' not in cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_LINKED_ACLS' not in cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_MAP_BACKEND' not in cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_COMPLEX' not in cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_ACTION_BASIC' not in cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy action tests failed! Name-based linking may not be working correctly.'

--- a/tests/haproxy_backend.yml
+++ b/tests/haproxy_backend.yml
@@ -1,0 +1,386 @@
+---
+
+- name: Testing HAProxy Backend Configuration with Name-Based Linking
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_backend'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing backends
+      ansibleguy.opnsense.list:
+      register: existing_entries
+      failed_when: >
+        'data' not in existing_entries
+
+    # === PREREQUISITE CLEANUP (BEFORE) ===
+    - name: Clean up test backends (before)
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_1'
+        - 'ANSIBLE_TEST_BACKEND_2'
+        - 'ANSIBLE_TEST_BACKEND_LINKING'
+        - 'ANSIBLE_TEST_BACKEND_UPDATE_LINKS'
+
+    - name: Clean up test servers (before)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_1'
+        - 'ANSIBLE_TEST_SERVER_2'
+        - 'ANSIBLE_TEST_SERVER_3'
+
+    - name: Clean up test errorfiles (before)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ERROR_1'
+        - 'ANSIBLE_TEST_ERROR_2'
+
+    - name: Clean up test groups (before)
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_GROUP_1'
+        - 'ANSIBLE_TEST_BACKEND_GROUP_2'
+
+    - name: Clean up test users (before)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_USER_1'
+        - 'ANSIBLE_TEST_BACKEND_USER_2'
+        - 'ANSIBLE_TEST_BACKEND_USER_3'
+
+    # === CREATE PREREQUISITE RESOURCES ===
+    - name: Create test servers for backend linking
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        address: "{{ item.address }}"
+        port: "{{ item.port }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_SERVER_1', desc: 'Backend test server 1', address: '192.168.1.10', port: 80 }
+        - { name: 'ANSIBLE_TEST_SERVER_2', desc: 'Backend test server 2', address: '192.168.1.11', port: 8080 }
+        - { name: 'ANSIBLE_TEST_SERVER_3', desc: 'Backend test server 3', address: '192.168.1.12', port: 9090 }
+
+    - name: Create test errorfiles for backend linking
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        code: "{{ item.code }}"
+        content: "{{ item.content }}"
+      loop:
+        - { name: 'ANSIBLE_TEST_ERROR_1', desc: 'Backend test 503 error', code: '503', content: '<html><body><h1>Service Unavailable - Backend Test</h1></body></html>' }
+        - { name: 'ANSIBLE_TEST_ERROR_2', desc: 'Backend test 500 error', code: '500', content: '<html><body><h1>Internal Server Error - Backend Test</h1></body></html>' }
+
+    - name: Create test users for backend auth linking
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        password: "{{ item.password }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_BACKEND_USER_1', desc: 'Backend auth test user 1', password: 'backendpass1' }
+        - { name: 'ANSIBLE_TEST_BACKEND_USER_2', desc: 'Backend auth test user 2', password: 'backendpass2' }
+        - { name: 'ANSIBLE_TEST_BACKEND_USER_3', desc: 'Backend auth test user 3', password: 'backendpass3' }
+
+    - name: Create test groups for backend auth linking
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        enabled: true
+        add_userlist: true
+        members: "{{ item.members }}"
+      loop:
+        - { name: 'ANSIBLE_TEST_BACKEND_GROUP_1', desc: 'Backend auth test group 1', members: ['ANSIBLE_TEST_BACKEND_USER_1', 'ANSIBLE_TEST_BACKEND_USER_2'] }
+        - { name: 'ANSIBLE_TEST_BACKEND_GROUP_2', desc: 'Backend auth test group 2', members: ['ANSIBLE_TEST_BACKEND_USER_3'] }
+
+    # === BASIC BACKEND TESTS (EXISTING) ===
+    - name: Removing test backend - does not exist
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_1'
+        state: 'absent'
+      register: opn_pre2
+      failed_when: >
+        opn_pre2.failed or
+        opn_pre2.changed
+
+    - name: Adding HAProxy backend 1
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_1'
+        description: 'Test backend 1'
+        enabled: true
+        mode: 'http'
+        algorithm: 'roundrobin'
+        health_check_enabled: true
+        health_check_interval: '5s'
+        health_check_timeout: '3s'
+        health_check_retries: 3
+      register: opn1
+      failed_when: >
+        opn1.failed or
+        not opn1.changed
+
+    - name: Adding HAProxy backend 1 - no change expected
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_1'
+        description: 'Test backend 1'
+        enabled: true
+        mode: 'http'
+        algorithm: 'roundrobin'
+        health_check_enabled: true
+        health_check_interval: '5s'
+        health_check_timeout: '3s'
+        health_check_retries: 3
+      register: opn2
+      failed_when: >
+        opn2.failed or
+        opn2.changed
+      when: not ansible_check_mode
+
+    - name: Modifying HAProxy backend 1
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_1'
+        description: 'Modified test backend 1'
+        enabled: true
+        mode: 'tcp'
+        algorithm: 'leastconn'
+        health_check_enabled: false
+      register: opn3
+      failed_when: >
+        opn3.failed or
+        not opn3.changed
+      when: not ansible_check_mode
+
+    - name: Disabling HAProxy backend 1
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_1'
+        enabled: false
+      register: opn4
+      failed_when: >
+        opn4.failed or
+        not opn4.changed
+      when: not ansible_check_mode
+
+    - name: Adding HAProxy backend 2
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_2'
+        description: 'Test backend 2'
+        enabled: true
+        mode: 'http'
+        algorithm: 'source'
+      register: opn5
+      failed_when: >
+        opn5.failed or
+        not opn5.changed
+
+    # === NAME-BASED LINKING TESTS ===
+    - name: Create backend with comprehensive name-based linking (check mode)
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_LINKING'
+        description: 'Backend testing name-based linking'
+        enabled: true
+        mode: 'http'
+        algorithm: 'leastconn'
+        linked_servers: ['ANSIBLE_TEST_SERVER_1', 'ANSIBLE_TEST_SERVER_2']  # Test server linking
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']  # Test errorfile linking
+        basic_auth_users: ['ANSIBLE_TEST_BACKEND_USER_1', 'ANSIBLE_TEST_BACKEND_USER_2']  # Test user linking
+        basic_auth_groups: ['ANSIBLE_TEST_BACKEND_GROUP_1']  # Test group linking
+      check_mode: true
+      register: opn_linking_check
+      failed_when: >
+        opn_linking_check.failed or
+        not opn_linking_check.changed
+
+    - name: Create backend with comprehensive name-based linking
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_LINKING'
+        description: 'Backend testing name-based linking'
+        enabled: true
+        mode: 'http'
+        algorithm: 'leastconn'
+        linked_servers: ['ANSIBLE_TEST_SERVER_1', 'ANSIBLE_TEST_SERVER_2']  # Test server linking
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']  # Test errorfile linking
+        basic_auth_users: ['ANSIBLE_TEST_BACKEND_USER_1', 'ANSIBLE_TEST_BACKEND_USER_2']  # Test user linking
+        basic_auth_groups: ['ANSIBLE_TEST_BACKEND_GROUP_1']  # Test group linking
+      register: opn_linking
+      failed_when: >
+        opn_linking.failed or
+        not opn_linking.changed
+
+    - name: Verify backend with linking creation
+      ansibleguy.opnsense.list:
+      register: opn_linking_verify
+
+    - name: Backend with linking should not change when run again
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_LINKING'
+        description: 'Backend testing name-based linking'
+        enabled: true
+        mode: 'http'
+        algorithm: 'leastconn'
+        linked_servers: ['ANSIBLE_TEST_SERVER_1', 'ANSIBLE_TEST_SERVER_2']
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']
+        basic_auth_users: ['ANSIBLE_TEST_BACKEND_USER_1', 'ANSIBLE_TEST_BACKEND_USER_2']
+        basic_auth_groups: ['ANSIBLE_TEST_BACKEND_GROUP_1']
+      register: opn_linking_no_change
+      failed_when: >
+        opn_linking_no_change.failed or
+        opn_linking_no_change.changed
+      when: not ansible_check_mode
+
+    # === UPDATE LINKING TESTS ===
+    - name: Create backend for link updating tests
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_UPDATE_LINKS'
+        description: 'Backend for testing link updates'
+        enabled: true
+        mode: 'tcp'
+        algorithm: 'roundrobin'
+        linked_servers: ['ANSIBLE_TEST_SERVER_1']  # Start with one server
+        basic_auth_users: ['ANSIBLE_TEST_BACKEND_USER_1']  # Start with one user
+      register: opn_update_links_initial
+      failed_when: >
+        opn_update_links_initial.failed or
+        not opn_update_links_initial.changed
+
+    - name: Update backend to add more linked resources
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_UPDATE_LINKS'
+        linked_servers: ['ANSIBLE_TEST_SERVER_1', 'ANSIBLE_TEST_SERVER_2', 'ANSIBLE_TEST_SERVER_3']  # Add more servers
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1', 'ANSIBLE_TEST_ERROR_2']  # Add errorfiles
+        basic_auth_users: ['ANSIBLE_TEST_BACKEND_USER_1', 'ANSIBLE_TEST_BACKEND_USER_2']  # Add another user
+        basic_auth_groups: ['ANSIBLE_TEST_BACKEND_GROUP_1', 'ANSIBLE_TEST_BACKEND_GROUP_2']  # Add groups
+      register: opn_update_links_add
+      failed_when: >
+        opn_update_links_add.failed or
+        not opn_update_links_add.changed
+      when: not ansible_check_mode
+
+    - name: Update backend to remove some linked resources
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_UPDATE_LINKS'
+        linked_servers: ['ANSIBLE_TEST_SERVER_2']  # Remove first and third server
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_2']  # Switch errorfile
+        basic_auth_users: ['ANSIBLE_TEST_BACKEND_USER_3']  # Switch to different user
+        basic_auth_groups: ['ANSIBLE_TEST_BACKEND_GROUP_2']  # Keep only second group
+      register: opn_update_links_remove
+      failed_when: >
+        opn_update_links_remove.failed or
+        not opn_update_links_remove.changed
+      when: not ansible_check_mode
+
+    - name: Update backend to clear all linked resources
+      ansibleguy.opnsense.haproxy_backend:
+        name: 'ANSIBLE_TEST_BACKEND_UPDATE_LINKS'
+        linked_servers: []  # Clear all servers
+        linked_errorfiles: []  # Clear all errorfiles
+        basic_auth_users: []  # Clear all users
+        basic_auth_groups: []  # Clear all groups
+      register: opn_update_links_clear
+      failed_when: >
+        opn_update_links_clear.failed or
+        not opn_update_links_clear.changed
+      when: not ansible_check_mode
+
+    # === CLEANUP ALL TEST RESOURCES (AFTER) ===
+    - name: Clean up test backends (after)
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_1'
+        - 'ANSIBLE_TEST_BACKEND_2'
+        - 'ANSIBLE_TEST_BACKEND_LINKING'
+        - 'ANSIBLE_TEST_BACKEND_UPDATE_LINKS'
+      when: not ansible_check_mode
+
+    - name: Clean up test servers (after)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_1'
+        - 'ANSIBLE_TEST_SERVER_2'
+        - 'ANSIBLE_TEST_SERVER_3'
+      when: not ansible_check_mode
+
+    - name: Clean up test errorfiles (after)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ERROR_1'
+        - 'ANSIBLE_TEST_ERROR_2'
+      when: not ansible_check_mode
+
+    - name: Clean up test groups (after)
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_GROUP_1'
+        - 'ANSIBLE_TEST_BACKEND_GROUP_2'
+      when: not ansible_check_mode
+
+    - name: Clean up test users (after)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_USER_1'
+        - 'ANSIBLE_TEST_BACKEND_USER_2'
+        - 'ANSIBLE_TEST_BACKEND_USER_3'
+      when: not ansible_check_mode
+
+    - name: Verify cleanup - no test backends should remain
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+      failed_when: >
+        'data' not in opn_cleanup_verify or
+        (opn_cleanup_verify.data | selectattr('name', 'match', 'ANSIBLE_TEST_BACKEND_.*') | list | length != 0)
+      when: not ansible_check_mode
+
+    # === COMPREHENSIVE TEST ASSERTIONS ===
+    - name: Show test results and verify name-based linking functionality
+      ansible.builtin.assert:
+        that:
+          # Basic backend tests
+          - opn1 is changed
+          - opn2 is not changed
+          - opn3 is changed
+          - opn4 is changed
+          - opn5 is changed
+          # Name-based linking tests
+          - opn_linking_check is changed
+          - opn_linking is changed
+          - opn_linking_no_change is not changed
+          # Link update tests
+          - opn_update_links_initial is changed
+          - opn_update_links_add is changed
+          - opn_update_links_remove is changed
+          - opn_update_links_clear is changed
+          # Verification tests
+          - "opn_linking_verify.data | length == (existing_entries.data | length + 3)"  # Added 3 backends in linking tests
+          - "'ANSIBLE_TEST_BACKEND_LINKING' in opn_linking_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_BACKEND_UPDATE_LINKS' in opn_linking_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_BACKEND_LINKING' not in opn_cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_BACKEND_UPDATE_LINKS' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy backend tests failed! Name-based linking functionality may not be working correctly.'

--- a/tests/haproxy_cpu.yml
+++ b/tests/haproxy_cpu.yml
@@ -1,0 +1,379 @@
+---
+
+- name: Testing HAProxy CPU Affinity Rules
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_cpu'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    # ========================================
+    # TEST PHASE 1: LIST AND INITIAL STATE
+    # ========================================
+    - name: Listing existing HAProxy CPU Affinity Rules
+      ansibleguy.opnsense.list:
+      register: opn_pre1
+      failed_when: >
+        'data' not in opn_pre1
+
+    - name: Show initial state
+      debug:
+        msg: "Found {{ opn_pre1.data | length }} existing CPU affinity rules"
+
+    # ========================================
+    # TEST PHASE 2: CREATE CPU AFFINITY RULES
+    # ========================================
+    - name: 'Create Specific Thread to CPU Binding Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread1_cpu0'
+        thread_id: 'x1'
+        cpu_id: 'x0'
+        state: present
+      register: cpu_specific1
+      failed_when: >
+        cpu_specific1.failed or
+        not cpu_specific1.changed
+
+    - name: 'Create Another Specific Thread to CPU Binding Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread2_cpu1'
+        thread_id: 'x2'
+        cpu_id: 'x1'
+        state: present
+      register: cpu_specific2
+      failed_when: >
+        cpu_specific2.failed or
+        not cpu_specific2.changed
+
+    - name: 'Create Odd Threads to Odd CPUs Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_odd_threads_odd_cpus'
+        thread_id: 'odd'
+        cpu_id: 'odd'
+        state: present
+      register: cpu_odd
+      failed_when: >
+        cpu_odd.failed or
+        not cpu_odd.changed
+
+    - name: 'Create Even Threads to Even CPUs Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_even_threads_even_cpus'
+        thread_id: 'even'
+        cpu_id: 'even'
+        state: present
+      register: cpu_even
+      failed_when: >
+        cpu_even.failed or
+        not cpu_even.changed
+
+    - name: 'Create All Threads to All CPUs Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_all_threads_all_cpus'
+        thread_id: 'all'
+        cpu_id: 'all'
+        state: present
+      register: cpu_all
+      failed_when: >
+        cpu_all.failed or
+        not cpu_all.changed
+
+    - name: 'Create High-Performance Thread Binding Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_high_perf_binding'
+        thread_id: 'x4'
+        cpu_id: 'x3'
+        state: present
+      register: cpu_highperf
+      failed_when: >
+        cpu_highperf.failed or
+        not cpu_highperf.changed
+
+    - name: Show creation results
+      debug:
+        msg: "✅ Created 6 CPU affinity rules successfully"
+
+    # ========================================
+    # TEST PHASE 3: VERIFICATION AND UPDATES
+    # ========================================
+    - name: 'List CPU affinity rules after creation'
+      ansibleguy.opnsense.list:
+      register: opn_post_create
+
+    - name: 'Verify all rules were created'
+      ansible.builtin.assert:
+        that:
+          - opn_post_create.data | length >= 6
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_thread1_cpu0') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_thread2_cpu1') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_odd_threads_odd_cpus') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_even_threads_even_cpus') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_all_threads_all_cpus') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_high_perf_binding') | list | length == 1"
+        fail_msg: "Not all CPU affinity rules were created properly"
+
+    - name: 'Update Specific Thread Rule - change CPU binding'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread1_cpu0'
+        thread_id: 'x1'
+        cpu_id: 'x2'
+        state: present
+      register: cpu_update1
+      failed_when: >
+        cpu_update1.failed or
+        not cpu_update1.changed
+      when: not ansible_check_mode
+
+    - name: 'Update High-Performance Rule - bind to different thread and CPU'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_high_perf_binding'
+        thread_id: 'x8'
+        cpu_id: 'x7'
+        state: present
+      register: cpu_update2
+      failed_when: >
+        cpu_update2.failed or
+        not cpu_update2.changed
+      when: not ansible_check_mode
+
+    # ========================================
+    # TEST PHASE 4: IDEMPOTENCY CHECKS
+    # ========================================
+    - name: 'Check idempotency - re-run same specific thread rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread1_cpu0'
+        thread_id: 'x1'
+        cpu_id: 'x2'
+        state: present
+      register: cpu_idempotent1
+      failed_when: >
+        cpu_idempotent1.failed or
+        cpu_idempotent1.changed
+      when: not ansible_check_mode
+
+    - name: 'Check idempotency - re-run same odd threads rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_odd_threads_odd_cpus'
+        thread_id: 'odd'
+        cpu_id: 'odd'
+        state: present
+      register: cpu_idempotent2
+      failed_when: >
+        cpu_idempotent2.failed or
+        cpu_idempotent2.changed
+      when: not ansible_check_mode
+
+    - name: 'Check idempotency - re-run same all threads rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_all_threads_all_cpus'
+        thread_id: 'all'
+        cpu_id: 'all'
+        state: present
+      register: cpu_idempotent3
+      failed_when: >
+        cpu_idempotent3.failed or
+        cpu_idempotent3.changed
+      when: not ansible_check_mode
+
+    - name: Show idempotency results
+      debug:
+        msg: "✅ Idempotency verified for CPU affinity rules"
+      when: not ansible_check_mode
+
+    # ========================================
+    # TEST PHASE 5: ERROR HANDLING
+    # ========================================
+    - name: 'Test error handling - missing name'
+      ansibleguy.opnsense.haproxy_cpu:
+        thread_id: 'x1'
+        cpu_id: 'x0'
+        state: present
+      register: cpu_error1
+      failed_when: not cpu_error1.failed
+      ignore_errors: true
+
+    - name: 'Test error handling - missing thread_id'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_missing_thread'
+        cpu_id: 'x0'
+        state: present
+      register: cpu_error2
+      failed_when: not cpu_error2.failed
+      ignore_errors: true
+
+    - name: 'Test error handling - missing cpu_id'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_missing_cpu'
+        thread_id: 'x1'
+        state: present
+      register: cpu_error3
+      failed_when: not cpu_error3.failed
+      ignore_errors: true
+
+    - name: Show error handling results
+      debug:
+        msg: "✅ Error handling working correctly"
+
+    # ========================================
+    # TEST PHASE 6: ADVANCED CONFIGURATIONS
+    # ========================================
+    - name: 'Create Advanced CPU Binding - Multiple specific cores'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_multi_core_binding'
+        thread_id: 'x16'
+        cpu_id: 'x15'
+        state: present
+      register: cpu_multicore
+      failed_when: >
+        cpu_multicore.failed or
+        not cpu_multicore.changed
+
+    - name: 'Create Load Balancing Thread Distribution Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_load_balance_threads'
+        thread_id: 'x3'
+        cpu_id: 'x4'
+        state: present
+      register: cpu_loadbalance
+      failed_when: >
+        cpu_loadbalance.failed or
+        not cpu_loadbalance.changed
+
+    - name: Show advanced configuration results
+      debug:
+        msg: "✅ Created advanced CPU affinity configurations"
+
+    # ========================================
+    # TEST PHASE 7: COMPREHENSIVE VALIDATION
+    # ========================================
+    - name: 'List all CPU rules for validation'
+      ansibleguy.opnsense.list:
+      register: opn_validation
+
+    - name: 'Verify comprehensive rule set'
+      ansible.builtin.assert:
+        that:
+          - opn_validation.data | length >= 8
+          - "opn_validation.data | selectattr('thread_id', 'equalto', 'odd') | list | length >= 1"
+          - "opn_validation.data | selectattr('thread_id', 'equalto', 'even') | list | length >= 1"
+          - "opn_validation.data | selectattr('thread_id', 'equalto', 'all') | list | length >= 1"
+          - "opn_validation.data | selectattr('cpu_id', 'equalto', 'all') | list | length >= 1"
+        fail_msg: "CPU affinity rule validation failed"
+
+    - name: Show validation results
+      debug:
+        msg: "✅ All CPU affinity rule types validated successfully"
+
+    # ========================================
+    # TEST PHASE 8: CLEANUP
+    # ========================================
+    - name: 'Remove Specific Thread 1 to CPU 0 Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread1_cpu0'
+        state: absent
+      register: cpu_remove1
+      failed_when: >
+        cpu_remove1.failed or
+        not cpu_remove1.changed
+
+    - name: 'Remove Specific Thread 2 to CPU 1 Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread2_cpu1'
+        state: absent
+      register: cpu_remove2
+      failed_when: >
+        cpu_remove2.failed or
+        not cpu_remove2.changed
+
+    - name: 'Remove Odd Threads to Odd CPUs Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_odd_threads_odd_cpus'
+        state: absent
+      register: cpu_remove3
+      failed_when: >
+        cpu_remove3.failed or
+        not cpu_remove3.changed
+
+    - name: 'Remove Even Threads to Even CPUs Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_even_threads_even_cpus'
+        state: absent
+      register: cpu_remove4
+      failed_when: >
+        cpu_remove4.failed or
+        not cpu_remove4.changed
+
+    - name: 'Remove All Threads to All CPUs Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_all_threads_all_cpus'
+        state: absent
+      register: cpu_remove5
+      failed_when: >
+        cpu_remove5.failed or
+        not cpu_remove5.changed
+
+    - name: 'Remove High-Performance Binding Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_high_perf_binding'
+        state: absent
+      register: cpu_remove6
+      failed_when: >
+        cpu_remove6.failed or
+        not cpu_remove6.changed
+
+    - name: 'Remove Multi-Core Binding Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_multi_core_binding'
+        state: absent
+      register: cpu_remove7
+      failed_when: >
+        cpu_remove7.failed or
+        not cpu_remove7.changed
+
+    - name: 'Remove Load Balance Threads Rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_load_balance_threads'
+        state: absent
+      register: cpu_remove8
+      failed_when: >
+        cpu_remove8.failed or
+        not cpu_remove8.changed
+
+    - name: 'Verify cleanup - attempt to remove non-existent rule'
+      ansibleguy.opnsense.haproxy_cpu:
+        name: 'test_thread1_cpu0'
+        state: absent
+      register: cpu_remove_again
+      failed_when: >
+        cpu_remove_again.failed or
+        cpu_remove_again.changed
+
+    - name: 'List CPU rules after cleanup'
+      ansibleguy.opnsense.list:
+      register: opn_post_cleanup
+
+    - name: 'Verify all test rules removed'
+      ansible.builtin.assert:
+        that:
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_thread1_cpu0') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_thread2_cpu1') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_odd_threads_odd_cpus') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_even_threads_even_cpus') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_all_threads_all_cpus') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_high_perf_binding') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_multi_core_binding') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_load_balance_threads') | list | length == 0"
+        fail_msg: "Cleanup failed - test rules still exist"
+
+    - name: Show final results
+      debug:
+        msg: "✅ All HAProxy CPU affinity rule tests completed successfully"

--- a/tests/haproxy_errorfile.yml
+++ b/tests/haproxy_errorfile.yml
@@ -1,0 +1,106 @@
+---
+
+- name: Testing HAProxy Error Files
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_errorfile'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing error files
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test error files (before)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_ERROR'
+        - 'ANSIBLE_TEST_2_ERROR'
+
+    - name: Add 503 error file (check)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: 'ANSIBLE_TEST_1_ERROR'
+        description: 'Test 503 error page'
+        code: '503'
+        content: '<html><body><h1>Service Unavailable</h1></body></html>'
+      check_mode: true
+      register: opn_error1_check
+
+    - name: Add 503 error file
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: 'ANSIBLE_TEST_1_ERROR'
+        description: 'Test 503 error page'
+        code: '503'
+        content: '<html><body><h1>Service Unavailable</h1></body></html>'
+      register: opn_error1
+
+    - name: Verify error file creation
+      ansibleguy.opnsense.list:
+      register: opn_error1_verify
+
+    - name: Add 404 error file
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: 'ANSIBLE_TEST_2_ERROR'
+        description: 'Test 404 error page'
+        code: '404'
+        content: '<html><body><h1>Page Not Found</h1></body></html>'
+      register: opn_error2
+
+    - name: Modify error file 1 content
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: 'ANSIBLE_TEST_1_ERROR'
+        description: 'Modified test 503 error page'
+        code: '503'
+        content: '<html><body><h1>Temporarily Unavailable</h1><p>Please try again later.</p></body></html>'
+      register: opn_error1_changed
+
+    - name: Error file 1 should not change (2)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: 'ANSIBLE_TEST_1_ERROR'
+        description: 'Modified test 503 error page'
+        code: '503'
+        content: '<html><body><h1>Temporarily Unavailable</h1><p>Please try again later.</p></body></html>'
+      register: opn_error1_changed2
+
+    - name: Disable error file 2
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: 'ANSIBLE_TEST_2_ERROR'
+        enabled: false
+      register: opn_error2_disabled
+
+    - name: Clean up test error files (after)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_ERROR'
+        - 'ANSIBLE_TEST_2_ERROR'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_error1_check is changed
+          - opn_error1 is changed
+          - opn_error2 is changed
+          - opn_error1_changed is changed
+          - opn_error1_changed2 is not changed
+          - opn_error2_disabled is changed
+          - "opn_error1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_ERROR' in opn_error1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_ERROR' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy error file tests failed!'

--- a/tests/haproxy_exporter.yml
+++ b/tests/haproxy_exporter.yml
@@ -1,0 +1,53 @@
+---
+
+- name: Testing HAProxy Configuration Export
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Export HAProxy configuration
+      ansibleguy.opnsense.haproxy_exporter:
+        export_type: 'config'
+      register: opn_config_export
+
+    - name: Export HAProxy configuration diff
+      ansibleguy.opnsense.haproxy_exporter:
+        export_type: 'diff'
+      register: opn_diff_export
+
+    - name: Download HAProxy data
+      ansibleguy.opnsense.haproxy_exporter:
+        export_type: 'download'
+        download_type: 'config'
+      register: opn_download_export
+
+    - name: Display configuration export
+      ansible.builtin.debug:
+        var: opn_config_export.result
+
+    - name: Display diff export
+      ansible.builtin.debug:
+        var: opn_diff_export.result
+
+    - name: Display download export
+      ansible.builtin.debug:
+        var: opn_download_export.result
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_config_export is not changed
+          - opn_diff_export is not changed
+          - opn_download_export is not changed
+          - opn_config_export.result is defined
+          - opn_diff_export.result is defined
+          - opn_download_export.result is defined
+        msg: 'HAProxy exporter tests failed!'

--- a/tests/haproxy_fcgi.yml
+++ b/tests/haproxy_fcgi.yml
@@ -1,0 +1,325 @@
+---
+
+- name: Testing HAProxy FCGI Applications
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_fcgi'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    # ========================================
+    # TEST PHASE 1: LIST AND INITIAL STATE
+    # ========================================
+    - name: Listing existing HAProxy FCGI Applications
+      ansibleguy.opnsense.list:
+      register: opn_pre1
+      failed_when: >
+        'data' not in opn_pre1
+
+    - name: Show initial state
+      debug:
+        msg: "Found {{ opn_pre1.data | length }} existing FCGI applications"
+
+    # ========================================
+    # TEST PHASE 2: CREATE FCGI APPLICATIONS
+    # ========================================
+    - name: 'Create PHP FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_php_app'
+        description: 'PHP FastCGI Application for Web Services'
+        docroot: '/var/www/html'
+        index: 'index.php'
+        state: present
+      register: fcgi_php
+      failed_when: >
+        fcgi_php.failed or
+        not fcgi_php.changed
+
+    - name: 'Create WordPress FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_wordpress_app'
+        description: 'WordPress FastCGI Application with Custom Settings'
+        docroot: '/var/www/wordpress'
+        index: 'index.php'
+        state: present
+      register: fcgi_wordpress
+      failed_when: >
+        fcgi_wordpress.failed or
+        not fcgi_wordpress.changed
+
+    - name: 'Create API FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_api_app'
+        description: 'REST API FastCGI Application'
+        docroot: '/var/www/api'
+        index: 'api.php'
+        state: present
+      register: fcgi_api
+      failed_when: >
+        fcgi_api.failed or
+        not fcgi_api.changed
+
+    - name: 'Create Laravel FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_laravel_app'
+        description: 'Laravel Framework FastCGI Application'
+        docroot: '/var/www/laravel/public'
+        index: 'index.php'
+        state: present
+      register: fcgi_laravel
+      failed_when: >
+        fcgi_laravel.failed or
+        not fcgi_laravel.changed
+
+    - name: 'Create Symfony FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_symfony_app'
+        description: 'Symfony Framework FastCGI Application'
+        docroot: '/var/www/symfony/public'
+        index: 'index.php'
+        state: present
+      register: fcgi_symfony
+      failed_when: >
+        fcgi_symfony.failed or
+        not fcgi_symfony.changed
+
+    - name: Show creation results
+      debug:
+        msg: "✅ Created 5 FCGI applications successfully"
+
+    # ========================================
+    # TEST PHASE 3: VERIFICATION AND UPDATES
+    # ========================================
+    - name: 'List FCGI applications after creation'
+      ansibleguy.opnsense.list:
+      register: opn_post_create
+
+    - name: 'Verify all applications were created'
+      ansible.builtin.assert:
+        that:
+          - opn_post_create.data | length >= 5
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_php_app') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_wordpress_app') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_api_app') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_laravel_app') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_symfony_app') | list | length == 1"
+        fail_msg: "Not all FCGI applications were created properly"
+
+    - name: 'Update PHP Application - change document root and index file'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_php_app'
+        description: 'Enhanced PHP FastCGI Application with Version 2'
+        docroot: '/var/www/html/v2'
+        index: 'main.php'
+        state: present
+      register: fcgi_php_update
+      failed_when: >
+        fcgi_php_update.failed or
+        not fcgi_php_update.changed
+      when: not ansible_check_mode
+
+    - name: 'Update WordPress Application - modify description and path'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_wordpress_app'
+        description: 'WordPress Multi-Site FastCGI Application'
+        docroot: '/var/www/wordpress-multisite'
+        index: 'index.php'
+        state: present
+      register: fcgi_wordpress_update
+      failed_when: >
+        fcgi_wordpress_update.failed or
+        not fcgi_wordpress_update.changed
+      when: not ansible_check_mode
+
+    # ========================================
+    # TEST PHASE 4: IDEMPOTENCY CHECKS
+    # ========================================
+    - name: 'Check idempotency - re-run same PHP application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_php_app'
+        description: 'Enhanced PHP FastCGI Application with Version 2'
+        docroot: '/var/www/html/v2'
+        index: 'main.php'
+        state: present
+      register: fcgi_idempotent1
+      failed_when: >
+        fcgi_idempotent1.failed or
+        fcgi_idempotent1.changed
+      when: not ansible_check_mode
+
+    - name: 'Check idempotency - re-run same API application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_api_app'
+        description: 'REST API FastCGI Application'
+        docroot: '/var/www/api'
+        index: 'api.php'
+        state: present
+      register: fcgi_idempotent2
+      failed_when: >
+        fcgi_idempotent2.failed or
+        fcgi_idempotent2.changed
+      when: not ansible_check_mode
+
+    - name: Show idempotency results
+      debug:
+        msg: "✅ Idempotency verified for FCGI applications"
+      when: not ansible_check_mode
+
+    # ========================================
+    # TEST PHASE 5: ERROR HANDLING
+    # ========================================
+    - name: 'Test error handling - missing name'
+      ansibleguy.opnsense.haproxy_fcgi:
+        description: 'Application without name'
+        docroot: '/var/www/test'
+        index: 'index.php'
+        state: present
+      register: fcgi_error1
+      failed_when: not fcgi_error1.failed
+      ignore_errors: true
+
+    - name: 'Test error handling - missing docroot'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_no_docroot'
+        description: 'Application without document root'
+        state: present
+      register: fcgi_error2
+      failed_when: not fcgi_error2.failed
+      ignore_errors: true
+
+    - name: Show error handling results
+      debug:
+        msg: "✅ Error handling working correctly"
+
+    # ========================================
+    # TEST PHASE 6: DIFFERENT CONFIGURATIONS
+    # ========================================
+    - name: 'Create FCGI Application with minimal configuration'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_minimal_app'
+        description: 'Minimal FastCGI Application'
+        state: present
+      register: fcgi_minimal
+      failed_when: >
+        fcgi_minimal.failed or
+        not fcgi_minimal.changed
+
+    - name: 'Create FCGI Application with complex path structure'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_complex_app'
+        description: 'Complex Path Structure FastCGI Application'
+        docroot: '/opt/applications/web-services/public_html'
+        index: 'bootstrap.php'
+        state: present
+      register: fcgi_complex
+      failed_when: >
+        fcgi_complex.failed or
+        not fcgi_complex.changed
+
+    - name: Show configuration variety results
+      debug:
+        msg: "✅ Created applications with various configuration types"
+
+    # ========================================
+    # TEST PHASE 7: CLEANUP
+    # ========================================
+    - name: 'Remove PHP FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_php_app'
+        state: absent
+      register: fcgi_remove1
+      failed_when: >
+        fcgi_remove1.failed or
+        not fcgi_remove1.changed
+
+    - name: 'Remove WordPress FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_wordpress_app'
+        state: absent
+      register: fcgi_remove2
+      failed_when: >
+        fcgi_remove2.failed or
+        not fcgi_remove2.changed
+
+    - name: 'Remove API FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_api_app'
+        state: absent
+      register: fcgi_remove3
+      failed_when: >
+        fcgi_remove3.failed or
+        not fcgi_remove3.changed
+
+    - name: 'Remove Laravel FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_laravel_app'
+        state: absent
+      register: fcgi_remove4
+      failed_when: >
+        fcgi_remove4.failed or
+        not fcgi_remove4.changed
+
+    - name: 'Remove Symfony FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_symfony_app'
+        state: absent
+      register: fcgi_remove5
+      failed_when: >
+        fcgi_remove5.failed or
+        not fcgi_remove5.changed
+
+    - name: 'Remove Minimal FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_minimal_app'
+        state: absent
+      register: fcgi_remove6
+      failed_when: >
+        fcgi_remove6.failed or
+        not fcgi_remove6.changed
+
+    - name: 'Remove Complex FastCGI Application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_complex_app'
+        state: absent
+      register: fcgi_remove7
+      failed_when: >
+        fcgi_remove7.failed or
+        not fcgi_remove7.changed
+
+    - name: 'Verify cleanup - attempt to remove non-existent application'
+      ansibleguy.opnsense.haproxy_fcgi:
+        name: 'test_php_app'
+        state: absent
+      register: fcgi_remove_again
+      failed_when: >
+        fcgi_remove_again.failed or
+        fcgi_remove_again.changed
+
+    - name: 'List FCGI applications after cleanup'
+      ansibleguy.opnsense.list:
+      register: opn_post_cleanup
+
+    - name: 'Verify all test applications removed'
+      ansible.builtin.assert:
+        that:
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_php_app') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_wordpress_app') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_api_app') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_laravel_app') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_symfony_app') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_minimal_app') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_complex_app') | list | length == 0"
+        fail_msg: "Cleanup failed - test applications still exist"
+
+    - name: Show final results
+      debug:
+        msg: "✅ All HAProxy FCGI application tests completed successfully"

--- a/tests/haproxy_frontend.yml
+++ b/tests/haproxy_frontend.yml
@@ -1,0 +1,437 @@
+---
+
+- name: Testing HAProxy Frontend Configuration with Name-Based Linking
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_frontend'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing frontends
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    # === PREREQUISITE CLEANUP (BEFORE) ===
+    - name: Clean up test frontends (before)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_FRONTEND'
+        - 'ANSIBLE_TEST_2_FRONTEND'
+        - 'ANSIBLE_TEST_3_FRONTEND'
+        - 'ANSIBLE_TEST_LINKING_FRONTEND'
+        - 'ANSIBLE_TEST_UPDATE_FRONTEND'
+
+    - name: Clean up test backends (before)
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_1'
+        - 'ANSIBLE_TEST_BACKEND_2'
+
+    - name: Clean up test servers (before)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_1'
+        - 'ANSIBLE_TEST_SERVER_2'
+
+    - name: Clean up test actions (before)
+      ansibleguy.opnsense.haproxy_action:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ACTION_1'
+        - 'ANSIBLE_TEST_ACTION_2'
+        - 'ANSIBLE_TEST_ACTION_3'
+
+    - name: Clean up test errorfiles (before)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ERROR_1'
+        - 'ANSIBLE_TEST_ERROR_2'
+
+    - name: Clean up test groups (before)
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_GROUP_1'
+        - 'ANSIBLE_TEST_GROUP_2'
+
+    - name: Clean up test users (before)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_USER_1'
+        - 'ANSIBLE_TEST_USER_2'
+        - 'ANSIBLE_TEST_USER_3'
+
+    # === CREATE PREREQUISITE RESOURCES ===
+    - name: Create test servers for backends
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        address: "{{ item.address }}"
+        port: "{{ item.port }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_SERVER_1', desc: 'Test server 1', address: '192.168.1.10', port: 80 }
+        - { name: 'ANSIBLE_TEST_SERVER_2', desc: 'Test server 2', address: '192.168.1.11', port: 80 }
+
+    - name: Create test backends
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        mode: 'http'
+        enabled: true
+        linked_servers: "{{ item.servers }}"
+      loop:
+        - { name: 'ANSIBLE_TEST_BACKEND_1', desc: 'Test backend 1', servers: ['ANSIBLE_TEST_SERVER_1'] }
+        - { name: 'ANSIBLE_TEST_BACKEND_2', desc: 'Test backend 2', servers: ['ANSIBLE_TEST_SERVER_2'] }
+
+    - name: Create test actions
+      ansibleguy.opnsense.haproxy_action:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        test_type: 'if'
+        action_type: "{{ item.action_type }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_ACTION_1', desc: 'Test action 1', action_type: 'http-request_allow' }
+        - { name: 'ANSIBLE_TEST_ACTION_2', desc: 'Test action 2', action_type: 'http-request_deny' }
+        - { name: 'ANSIBLE_TEST_ACTION_3', desc: 'Test action 3', action_type: 'http-response_set-header' }
+
+    - name: Create test errorfiles
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        code: "{{ item.code }}"
+        content: "{{ item.content }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_ERROR_1', desc: 'Test 503 error', code: '503', content: '<html><body><h1>Service Unavailable</h1></body></html>' }
+        - { name: 'ANSIBLE_TEST_ERROR_2', desc: 'Test 404 error', code: '404', content: '<html><body><h1>Not Found</h1></body></html>' }
+
+    - name: Create test users
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        password: "{{ item.password }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_USER_1', desc: 'Test user 1', password: 'pass1' }
+        - { name: 'ANSIBLE_TEST_USER_2', desc: 'Test user 2', password: 'pass2' }
+        - { name: 'ANSIBLE_TEST_USER_3', desc: 'Test user 3', password: 'pass3' }
+
+    - name: Create test groups
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        enabled: true
+        add_userlist: true
+        members: "{{ item.members }}"
+      loop:
+        - { name: 'ANSIBLE_TEST_GROUP_1', desc: 'Test group 1', members: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_2'] }
+        - { name: 'ANSIBLE_TEST_GROUP_2', desc: 'Test group 2', members: ['ANSIBLE_TEST_USER_3'] }
+
+    # === BASIC FRONTEND TESTS (EXISTING) ===
+
+    - name: Add frontend (check)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_1_FRONTEND'
+        description: 'Test frontend 1'
+        bind_address: '127.0.0.1'
+        bind_port: 8080
+        mode: 'http'
+      check_mode: true
+      register: opn_frontend1_check
+
+    - name: Add frontend
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_1_FRONTEND'
+        description: 'Test frontend 1'
+        bind_address: '127.0.0.1'
+        bind_port: 8080
+        mode: 'http'
+      register: opn_frontend1
+
+    - name: Verify frontend creation
+      ansibleguy.opnsense.list:
+      register: opn_frontend1_verify
+
+    - name: Add frontend 2
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_2_FRONTEND'
+        description: 'Test frontend 2'
+        bind_address: '0.0.0.0'
+        bind_port: 443
+        ssl_enabled: true
+        mode: 'http'
+        max_connections: 1000
+      register: opn_frontend2
+
+    - name: Add frontend 3 (TCP)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_3_FRONTEND'
+        description: 'Test TCP frontend'
+        bind_address: '10.0.0.1'
+        bind_port: 5432
+        mode: 'tcp'
+        log_enabled: true
+      register: opn_frontend3
+
+    - name: Modify frontend 1
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_1_FRONTEND'
+        description: 'Modified test frontend 1'
+        bind_address: '127.0.0.1'
+        bind_port: 8080
+        mode: 'http'
+        max_connections: 500
+        log_enabled: true
+      register: opn_frontend1_changed
+
+    - name: Frontend 1 should not change (2)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_1_FRONTEND'
+        description: 'Modified test frontend 1'
+        bind_address: '127.0.0.1'
+        bind_port: 8080
+        mode: 'http'
+        max_connections: 500
+        log_enabled: true
+      register: opn_frontend1_changed2
+
+    - name: Disable frontend 3
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_3_FRONTEND'
+        enabled: false
+      register: opn_frontend3_disabled
+
+    # === NAME-BASED LINKING TESTS ===
+    - name: Create frontend with name-based linking (check)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_LINKING_FRONTEND'
+        description: 'Test frontend with name-based linking'
+        bind_address: '127.0.0.1'
+        bind_port: 9090
+        mode: 'http'
+        default_backend: 'ANSIBLE_TEST_BACKEND_1'
+        linked_actions: ['ANSIBLE_TEST_ACTION_1', 'ANSIBLE_TEST_ACTION_2']
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']
+        basic_auth_users: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_2']
+        basic_auth_groups: ['ANSIBLE_TEST_GROUP_1']
+      check_mode: true
+      register: opn_frontend_linking_check
+
+    - name: Create frontend with name-based linking
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_LINKING_FRONTEND'
+        description: 'Test frontend with name-based linking'
+        bind_address: '127.0.0.1'
+        bind_port: 9090
+        mode: 'http'
+        default_backend: 'ANSIBLE_TEST_BACKEND_1'
+        linked_actions: ['ANSIBLE_TEST_ACTION_1', 'ANSIBLE_TEST_ACTION_2']
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']
+        basic_auth_users: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_2']
+        basic_auth_groups: ['ANSIBLE_TEST_GROUP_1']
+      register: opn_frontend_linking
+
+    - name: Verify frontend with linking creation
+      ansibleguy.opnsense.list:
+      register: opn_frontend_linking_verify
+
+    - name: Frontend with linking should not change (idempotent)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_LINKING_FRONTEND'
+        description: 'Test frontend with name-based linking'
+        bind_address: '127.0.0.1'
+        bind_port: 9090
+        mode: 'http'
+        default_backend: 'ANSIBLE_TEST_BACKEND_1'
+        linked_actions: ['ANSIBLE_TEST_ACTION_1', 'ANSIBLE_TEST_ACTION_2']
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']
+        basic_auth_users: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_2']
+        basic_auth_groups: ['ANSIBLE_TEST_GROUP_1']
+      register: opn_frontend_linking_unchanged
+
+    # === LINK UPDATE TESTS ===
+    - name: Create frontend for link update testing
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        description: 'Test frontend for link updates'
+        bind_address: '127.0.0.1'
+        bind_port: 9191
+        mode: 'http'
+        default_backend: 'ANSIBLE_TEST_BACKEND_1'
+        linked_actions: ['ANSIBLE_TEST_ACTION_1']
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1']
+        basic_auth_users: ['ANSIBLE_TEST_USER_1']
+        basic_auth_groups: ['ANSIBLE_TEST_GROUP_1']
+      register: opn_frontend_update_create
+
+    - name: Update default backend
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        default_backend: 'ANSIBLE_TEST_BACKEND_2'
+      register: opn_frontend_backend_update
+
+    - name: Update linked actions (add one, keep one)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        linked_actions: ['ANSIBLE_TEST_ACTION_1', 'ANSIBLE_TEST_ACTION_3']
+      register: opn_frontend_actions_update
+
+    - name: Update linked errorfiles (replace with different one)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_2']
+      register: opn_frontend_errorfiles_update
+
+    - name: Update basic auth users (add one, remove one)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        basic_auth_users: ['ANSIBLE_TEST_USER_2', 'ANSIBLE_TEST_USER_3']
+      register: opn_frontend_users_update
+
+    - name: Update basic auth groups (change to different group)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        basic_auth_groups: ['ANSIBLE_TEST_GROUP_2']
+      register: opn_frontend_groups_update
+
+    - name: Clear all links (test removing links)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        default_backend: ''
+        linked_actions: []
+        linked_errorfiles: []
+        basic_auth_users: []
+        basic_auth_groups: []
+      register: opn_frontend_clear_links
+
+    - name: Re-add all links with different values
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UPDATE_FRONTEND'
+        default_backend: 'ANSIBLE_TEST_BACKEND_1'
+        linked_actions: ['ANSIBLE_TEST_ACTION_2', 'ANSIBLE_TEST_ACTION_3']
+        linked_errorfiles: ['ANSIBLE_TEST_ERROR_1', 'ANSIBLE_TEST_ERROR_2']
+        basic_auth_users: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_3']
+        basic_auth_groups: ['ANSIBLE_TEST_GROUP_1', 'ANSIBLE_TEST_GROUP_2']
+      register: opn_frontend_readd_links
+
+    # === CLEANUP ALL TEST RESOURCES ===
+    - name: Clean up test frontends (after)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_FRONTEND'
+        - 'ANSIBLE_TEST_2_FRONTEND'
+        - 'ANSIBLE_TEST_3_FRONTEND'
+        - 'ANSIBLE_TEST_LINKING_FRONTEND'
+        - 'ANSIBLE_TEST_UPDATE_FRONTEND'
+
+    - name: Clean up test backends (after)
+      ansibleguy.opnsense.haproxy_backend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_BACKEND_1'
+        - 'ANSIBLE_TEST_BACKEND_2'
+
+    - name: Clean up test servers (after)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_SERVER_1'
+        - 'ANSIBLE_TEST_SERVER_2'
+
+    - name: Clean up test actions (after)
+      ansibleguy.opnsense.haproxy_action:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ACTION_1'
+        - 'ANSIBLE_TEST_ACTION_2'
+        - 'ANSIBLE_TEST_ACTION_3'
+
+    - name: Clean up test errorfiles (after)
+      ansibleguy.opnsense.haproxy_errorfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_ERROR_1'
+        - 'ANSIBLE_TEST_ERROR_2'
+
+    - name: Clean up test groups (after)
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_GROUP_1'
+        - 'ANSIBLE_TEST_GROUP_2'
+
+    - name: Clean up test users (after)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_USER_1'
+        - 'ANSIBLE_TEST_USER_2'
+        - 'ANSIBLE_TEST_USER_3'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          # Basic frontend tests
+          - opn_frontend1_check is changed
+          - opn_frontend1 is changed
+          - opn_frontend2 is changed
+          - opn_frontend3 is changed
+          - opn_frontend1_changed is changed
+          - opn_frontend1_changed2 is not changed
+          - opn_frontend3_disabled is changed
+          # Name-based linking tests
+          - opn_frontend_linking_check is changed
+          - opn_frontend_linking is changed
+          - opn_frontend_linking_unchanged is not changed
+          # Link update tests
+          - opn_frontend_update_create is changed
+          - opn_frontend_backend_update is changed
+          - opn_frontend_actions_update is changed
+          - opn_frontend_errorfiles_update is changed
+          - opn_frontend_users_update is changed
+          - opn_frontend_groups_update is changed
+          - opn_frontend_clear_links is changed
+          - opn_frontend_readd_links is changed
+          # Data verification
+          - "opn_frontend1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_FRONTEND' in opn_frontend1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_LINKING_FRONTEND' in opn_frontend_linking_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_FRONTEND' not in opn_cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_LINKING_FRONTEND' not in opn_cleanup_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_UPDATE_FRONTEND' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy frontend tests failed! Name-based linking may not be working correctly.'

--- a/tests/haproxy_general.yml
+++ b/tests/haproxy_general.yml
@@ -1,0 +1,79 @@
+---
+
+- name: Testing HAProxy General Configuration
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_general'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Listing HAProxy General config
+      ansibleguy.opnsense.list:
+      register: opn_pre1
+      failed_when: >
+        'data' not in opn_pre1
+
+    - name: Configure HAProxy General - Enable with basic settings
+      ansibleguy.opnsense.haproxy_general:
+        enabled: true
+        graceful_stop: true
+        hard_stop_after: '60s'
+        seamless_reload: true
+        show_intro: false
+      register: opn1
+      failed_when: >
+        opn1.failed or
+        not opn1.changed
+
+    - name: Configure HAProxy General - No change expected
+      ansibleguy.opnsense.haproxy_general:
+        enabled: true
+        graceful_stop: true
+        hard_stop_after: '60s'
+        seamless_reload: true
+        show_intro: false
+      register: opn2
+      failed_when: >
+        opn2.failed or
+        opn2.changed
+      when: not ansible_check_mode
+
+    - name: Configure HAProxy General - Modify settings
+      ansibleguy.opnsense.haproxy_general:
+        enabled: true
+        graceful_stop: false
+        hard_stop_after: '120s'
+        seamless_reload: false
+        show_intro: true
+      register: opn3
+      failed_when: >
+        opn3.failed or
+        not opn3.changed
+      when: not ansible_check_mode
+
+    - name: Disable HAProxy
+      ansibleguy.opnsense.haproxy_general:
+        enabled: false
+      register: opn4
+      failed_when: >
+        opn4.failed or
+        not opn4.changed
+      when: not ansible_check_mode
+
+    - name: Disable HAProxy - No change expected
+      ansibleguy.opnsense.haproxy_general:
+        enabled: false
+      register: opn5
+      failed_when: >
+        opn5.failed or
+        opn5.changed
+      when: not ansible_check_mode

--- a/tests/haproxy_group.yml
+++ b/tests/haproxy_group.yml
@@ -1,0 +1,163 @@
+---
+
+- name: Testing HAProxy User Groups
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_group'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing groups
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test groups and users (before)
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_GROUP'
+        - 'ANSIBLE_TEST_2_GROUP'
+        - 'ANSIBLE_TEST_3_GROUP'
+
+    - name: Clean up test users (before)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_USER_1'
+        - 'ANSIBLE_TEST_USER_2'
+        - 'ANSIBLE_TEST_USER_3'
+
+    - name: Create test users for group membership testing
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        password: "{{ item.password }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_USER_1', desc: 'Test user 1', password: 'pass1' }
+        - { name: 'ANSIBLE_TEST_USER_2', desc: 'Test user 2', password: 'pass2' }
+        - { name: 'ANSIBLE_TEST_USER_3', desc: 'Test user 3', password: 'pass3' }
+
+    - name: Add group (check)
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_1_GROUP'
+        description: 'Test group 1'
+        add_userlist: false
+        enabled: true
+      check_mode: true
+      register: opn_group1_check
+
+    - name: Add group
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_1_GROUP'
+        description: 'Test group 1'
+        add_userlist: false
+        enabled: true
+      register: opn_group1
+
+    - name: Verify group creation
+      ansibleguy.opnsense.list:
+      register: opn_group1_verify
+
+    - name: Add admin group with userlist and name-based user linking
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_2_GROUP'
+        description: 'Test admin group'
+        add_userlist: true
+        enabled: true
+        members: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_2']  # Test name-based linking
+      register: opn_group2
+
+    - name: Modify group 1 description
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_1_GROUP'
+        description: 'Modified test group 1'
+        add_userlist: false
+        enabled: true
+      register: opn_group1_changed
+
+    - name: Group 1 should not change (2)
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_1_GROUP'
+        description: 'Modified test group 1'
+        add_userlist: false
+        enabled: true
+      register: opn_group1_changed2
+
+    - name: Enable userlist for group 1 and add members
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_1_GROUP'
+        add_userlist: true
+        members: ['ANSIBLE_TEST_USER_3']  # Test adding members to existing group
+      register: opn_group1_userlist
+
+    - name: Create group with all users for comprehensive testing
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_3_GROUP'
+        description: 'Test group with all users'
+        add_userlist: true
+        enabled: true
+        members: ['ANSIBLE_TEST_USER_1', 'ANSIBLE_TEST_USER_2', 'ANSIBLE_TEST_USER_3']
+      register: opn_group3
+
+    - name: Update group 2 membership (add one, remove one)
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_2_GROUP'
+        members: ['ANSIBLE_TEST_USER_2', 'ANSIBLE_TEST_USER_3']  # Changed membership
+      register: opn_group2_members_changed
+
+    - name: Disable group 2
+      ansibleguy.opnsense.haproxy_group:
+        name: 'ANSIBLE_TEST_2_GROUP'
+        enabled: false
+      register: opn_group2_disabled
+
+    - name: Clean up test groups (after)
+      ansibleguy.opnsense.haproxy_group:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_GROUP'
+        - 'ANSIBLE_TEST_2_GROUP'
+        - 'ANSIBLE_TEST_3_GROUP'
+
+    - name: Clean up test users (after)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_USER_1'
+        - 'ANSIBLE_TEST_USER_2'
+        - 'ANSIBLE_TEST_USER_3'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_group1_check is changed
+          - opn_group1 is changed
+          - opn_group2 is changed
+          - opn_group1_changed is changed
+          - opn_group1_changed2 is not changed
+          - opn_group1_userlist is changed
+          - opn_group3 is changed
+          - opn_group2_members_changed is changed
+          - opn_group2_disabled is changed
+          - "opn_group1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_GROUP' in opn_group1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_GROUP' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy group tests failed! Name-based user linking may not be working correctly.'

--- a/tests/haproxy_healthcheck.yml
+++ b/tests/haproxy_healthcheck.yml
@@ -1,0 +1,124 @@
+---
+
+- name: Testing HAProxy Health Checks
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_healthcheck'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing health checks
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test health checks (before)
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_HEALTH'
+        - 'ANSIBLE_TEST_2_HEALTH'
+        - 'ANSIBLE_TEST_3_HEALTH'
+
+    - name: Add HTTP health check (check)
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_1_HEALTH'
+        description: 'Test HTTP health check'
+        type: 'http'
+        interval: '5s'
+        ssl: 'nopref'
+      check_mode: true
+      register: opn_health1_check
+
+    - name: Add HTTP health check
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_1_HEALTH'
+        description: 'Test HTTP health check'
+        type: 'http'
+        interval: '5s'
+        ssl: 'nopref'
+      register: opn_health1
+
+    - name: Verify health check creation
+      ansibleguy.opnsense.list:
+      register: opn_health1_verify
+
+    - name: Add SSL health check with SNI
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_2_HEALTH'
+        description: 'Test SSL health check'
+        type: 'http'
+        interval: '10s'
+        ssl: 'sslsni'
+        ssl_sni: 'api.example.com'
+      register: opn_health2
+
+    - name: Add MySQL health check
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_3_HEALTH'
+        description: 'Test MySQL health check'
+        type: 'mysql'
+        interval: '30s'
+        ssl: 'nossl'
+      register: opn_health3
+
+    - name: Modify health check 1 interval
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_1_HEALTH'
+        description: 'Modified test HTTP health check'
+        type: 'http'
+        interval: '3s'
+        ssl: 'nopref'
+      register: opn_health1_changed
+
+    - name: Health check 1 should not change (2)
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_1_HEALTH'
+        description: 'Modified test HTTP health check'
+        type: 'http'
+        interval: '3s'
+        ssl: 'nopref'
+      register: opn_health1_changed2
+
+    - name: Disable health check 3
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: 'ANSIBLE_TEST_3_HEALTH'
+        enabled: false
+      register: opn_health3_disabled
+
+    - name: Clean up test health checks (after)
+      ansibleguy.opnsense.haproxy_healthcheck:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_HEALTH'
+        - 'ANSIBLE_TEST_2_HEALTH'
+        - 'ANSIBLE_TEST_3_HEALTH'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_health1_check is changed
+          - opn_health1 is changed
+          - opn_health2 is changed
+          - opn_health3 is changed
+          - opn_health1_changed is changed
+          - opn_health1_changed2 is not changed
+          - opn_health3_disabled is changed
+          - "opn_health1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_HEALTH' in opn_health1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_HEALTH' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy health check tests failed!'

--- a/tests/haproxy_lua.yml
+++ b/tests/haproxy_lua.yml
@@ -1,0 +1,396 @@
+---
+
+- name: Testing HAProxy Lua Scripts
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_lua'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    # ========================================
+    # TEST PHASE 1: LIST AND INITIAL STATE
+    # ========================================
+    - name: Listing existing HAProxy Lua Scripts
+      ansibleguy.opnsense.list:
+      register: opn_pre1
+      failed_when: >
+        'data' not in opn_pre1
+
+    - name: Show initial state
+      debug:
+        msg: "Found {{ opn_pre1.data | length }} existing Lua scripts"
+
+    # ========================================
+    # TEST PHASE 2: CREATE LUA SCRIPTS
+    # ========================================
+    - name: 'Create Authentication Lua Script with preload'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_auth_lua'
+        description: 'Authentication Lua Script for Bearer Token Validation'
+        enabled: true
+        preload: true
+        filename_scheme: 'name'
+        content: |
+          function authenticate(txn)
+              local auth_header = txn.http:req_get_headers()["authorization"]
+              if auth_header and auth_header[0] then
+                  local token = string.match(auth_header[0], "Bearer%s+(.+)")
+                  if token and string.len(token) > 10 then
+                      core.log(core.info, "Authentication successful for token: " .. string.sub(token, 1, 10) .. "...")
+                      return true
+                  end
+              end
+              core.log(core.warning, "Authentication failed - invalid or missing token")
+              return false
+          end
+        state: present
+      register: lua_auth
+      failed_when: >
+        lua_auth.failed or
+        not lua_auth.changed
+
+    - name: 'Create Request Logger Lua Script without preload'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_logger_lua'
+        description: 'Request Logger Lua Script for Traffic Analysis'
+        enabled: true
+        preload: false
+        filename_scheme: 'id'
+        content: |
+          function log_request(txn)
+              local method = txn.http:req_get_method()
+              local path = txn.http:req_get_path()
+              local ip = txn.f:src()
+              local user_agent = txn.http:req_get_headers()["user-agent"]
+              
+              local log_msg = string.format(
+                  "Request: %s %s from %s (UA: %s)", 
+                  method, 
+                  path, 
+                  ip, 
+                  user_agent and user_agent[0] or "unknown"
+              )
+              core.log(core.info, log_msg)
+          end
+        state: present
+      register: lua_logger
+      failed_when: >
+        lua_logger.failed or
+        not lua_logger.changed
+
+    - name: 'Create Rate Limiting Lua Script with complex logic'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_ratelimit_lua'
+        description: 'Rate Limiting Lua Script with IP-based Throttling'
+        enabled: true
+        preload: true
+        filename_scheme: 'name'
+        content: |
+          local rate_limit = {}
+          
+          function check_rate_limit(txn)
+              local client_ip = txn.f:src()
+              local current_time = os.time()
+              local limit = 100  -- requests per minute
+              local window = 60  -- seconds
+              
+              if not rate_limit[client_ip] then
+                  rate_limit[client_ip] = {count = 1, timestamp = current_time}
+                  return true
+              end
+              
+              local client_data = rate_limit[client_ip]
+              if (current_time - client_data.timestamp) > window then
+                  client_data.count = 1
+                  client_data.timestamp = current_time
+                  return true
+              end
+              
+              if client_data.count >= limit then
+                  core.log(core.warning, "Rate limit exceeded for IP: " .. client_ip)
+                  return false
+              end
+              
+              client_data.count = client_data.count + 1
+              return true
+          end
+        state: present
+      register: lua_ratelimit
+      failed_when: >
+        lua_ratelimit.failed or
+        not lua_ratelimit.changed
+
+    - name: 'Create Header Manipulation Lua Script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_headers_lua'
+        description: 'Header Manipulation Lua Script for Custom Processing'
+        enabled: false
+        filename_scheme: 'id'
+        content: |
+          function process_headers(txn)
+              -- Add custom headers
+              txn.http:req_add_header("X-Processed-By", "HAProxy-Lua")
+              txn.http:req_add_header("X-Request-ID", "req-" .. os.time() .. "-" .. math.random(1000, 9999))
+              
+              -- Log processing
+              local host = txn.http:req_get_headers()["host"]
+              if host and host[0] then
+                  core.log(core.info, "Processing request for host: " .. host[0])
+              end
+          end
+        state: present
+      register: lua_headers
+      failed_when: >
+        lua_headers.failed or
+        not lua_headers.changed
+
+    - name: Show creation results
+      debug:
+        msg: "✅ Created 4 Lua scripts successfully"
+
+    # ========================================
+    # TEST PHASE 3: VERIFICATION AND UPDATES
+    # ========================================
+    - name: 'List Lua scripts after creation'
+      ansibleguy.opnsense.list:
+      register: opn_post_create
+
+    - name: 'Verify all scripts were created'
+      ansible.builtin.assert:
+        that:
+          - opn_post_create.data | length >= 4
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_auth_lua') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_logger_lua') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_ratelimit_lua') | list | length == 1"
+          - "opn_post_create.data | selectattr('name', 'equalto', 'test_headers_lua') | list | length == 1"
+        fail_msg: "Not all Lua scripts were created properly"
+
+    - name: 'Update Authentication Lua Script - modify content and enable'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_auth_lua'
+        description: 'Enhanced Authentication Lua Script with JWT Support'
+        enabled: true
+        preload: true
+        filename_scheme: 'name'
+        content: |
+          function authenticate(txn)
+              local auth_header = txn.http:req_get_headers()["authorization"]
+              if auth_header and auth_header[0] then
+                  local token = string.match(auth_header[0], "Bearer%s+(.+)")
+                  if token then
+                      -- Basic JWT structure validation
+                      local parts = 0
+                      for _ in string.gmatch(token, "[^%.]+") do
+                          parts = parts + 1
+                      end
+                      if parts == 3 and string.len(token) > 20 then
+                          core.log(core.info, "JWT token validation successful")
+                          return true
+                      end
+                  end
+              end
+              core.log(core.warning, "Authentication failed - invalid JWT token")
+              return false
+          end
+        state: present
+      register: lua_auth_update
+      failed_when: >
+        lua_auth_update.failed or
+        not lua_auth_update.changed
+      when: not ansible_check_mode
+
+    - name: 'Enable disabled Header Manipulation script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_headers_lua'
+        description: 'Header Manipulation Lua Script for Custom Processing'
+        enabled: true
+        filename_scheme: 'id'
+        content: |
+          function process_headers(txn)
+              -- Add custom headers
+              txn.http:req_add_header("X-Processed-By", "HAProxy-Lua")
+              txn.http:req_add_header("X-Request-ID", "req-" .. os.time() .. "-" .. math.random(1000, 9999))
+              
+              -- Log processing
+              local host = txn.http:req_get_headers()["host"]
+              if host and host[0] then
+                  core.log(core.info, "Processing request for host: " .. host[0])
+              end
+          end
+        state: present
+      register: lua_headers_enable
+      failed_when: >
+        lua_headers_enable.failed or
+        not lua_headers_enable.changed
+      when: not ansible_check_mode
+
+    # ========================================
+    # TEST PHASE 4: IDEMPOTENCY CHECKS
+    # ========================================
+    - name: 'Check idempotency - re-run same Authentication Lua script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_auth_lua'
+        description: 'Enhanced Authentication Lua Script with JWT Support'
+        enabled: true
+        preload: true
+        filename_scheme: 'name'
+        content: |
+          function authenticate(txn)
+              local auth_header = txn.http:req_get_headers()["authorization"]
+              if auth_header and auth_header[0] then
+                  local token = string.match(auth_header[0], "Bearer%s+(.+)")
+                  if token then
+                      -- Basic JWT structure validation
+                      local parts = 0
+                      for _ in string.gmatch(token, "[^%.]+") do
+                          parts = parts + 1
+                      end
+                      if parts == 3 and string.len(token) > 20 then
+                          core.log(core.info, "JWT token validation successful")
+                          return true
+                      end
+                  end
+              end
+              core.log(core.warning, "Authentication failed - invalid JWT token")
+              return false
+          end
+        state: present
+      register: lua_idempotent1
+      failed_when: >
+        lua_idempotent1.failed or
+        lua_idempotent1.changed
+      when: not ansible_check_mode
+
+    - name: 'Check idempotency - re-run same Logger Lua script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_logger_lua'
+        description: 'Request Logger Lua Script for Traffic Analysis'
+        enabled: true
+        preload: false
+        filename_scheme: 'id'
+        content: |
+          function log_request(txn)
+              local method = txn.http:req_get_method()
+              local path = txn.http:req_get_path()
+              local ip = txn.f:src()
+              local user_agent = txn.http:req_get_headers()["user-agent"]
+              
+              local log_msg = string.format(
+                  "Request: %s %s from %s (UA: %s)", 
+                  method, 
+                  path, 
+                  ip, 
+                  user_agent and user_agent[0] or "unknown"
+              )
+              core.log(core.info, log_msg)
+          end
+        state: present
+      register: lua_idempotent2
+      failed_when: >
+        lua_idempotent2.failed or
+        lua_idempotent2.changed
+      when: not ansible_check_mode
+
+    - name: Show idempotency results
+      debug:
+        msg: "✅ Idempotency verified for Lua scripts"
+      when: not ansible_check_mode
+
+    # ========================================
+    # TEST PHASE 5: ERROR HANDLING
+    # ========================================
+    - name: 'Test error handling - missing name'
+      ansibleguy.opnsense.haproxy_lua:
+        description: 'Script without name'
+        content: 'function test() end'
+        state: present
+      register: lua_error1
+      failed_when: not lua_error1.failed
+      ignore_errors: true
+
+    - name: 'Test error handling - missing content'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_no_content'
+        description: 'Script without content'
+        state: present
+      register: lua_error2
+      failed_when: not lua_error2.failed
+      ignore_errors: true
+
+    - name: Show error handling results
+      debug:
+        msg: "✅ Error handling working correctly"
+
+    # ========================================
+    # TEST PHASE 6: CLEANUP
+    # ========================================
+    - name: 'Remove Authentication Lua Script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_auth_lua'
+        state: absent
+      register: lua_remove1
+      failed_when: >
+        lua_remove1.failed or
+        not lua_remove1.changed
+
+    - name: 'Remove Logger Lua Script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_logger_lua'
+        state: absent
+      register: lua_remove2
+      failed_when: >
+        lua_remove2.failed or
+        not lua_remove2.changed
+
+    - name: 'Remove Rate Limit Lua Script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_ratelimit_lua'
+        state: absent
+      register: lua_remove3
+      failed_when: >
+        lua_remove3.failed or
+        not lua_remove3.changed
+
+    - name: 'Remove Header Manipulation Lua Script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_headers_lua'
+        state: absent
+      register: lua_remove4
+      failed_when: >
+        lua_remove4.failed or
+        not lua_remove4.changed
+
+    - name: 'Verify cleanup - attempt to remove non-existent script'
+      ansibleguy.opnsense.haproxy_lua:
+        name: 'test_auth_lua'
+        state: absent
+      register: lua_remove_again
+      failed_when: >
+        lua_remove_again.failed or
+        lua_remove_again.changed
+
+    - name: 'List Lua scripts after cleanup'
+      ansibleguy.opnsense.list:
+      register: opn_post_cleanup
+
+    - name: 'Verify all test scripts removed'
+      ansible.builtin.assert:
+        that:
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_auth_lua') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_logger_lua') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_ratelimit_lua') | list | length == 0"
+          - "opn_post_cleanup.data | selectattr('name', 'equalto', 'test_headers_lua') | list | length == 0"
+        fail_msg: "Cleanup failed - test scripts still exist"
+
+    - name: Show final results
+      debug:
+        msg: "✅ All HAProxy Lua script tests completed successfully"

--- a/tests/haproxy_mailer.yml
+++ b/tests/haproxy_mailer.yml
@@ -1,0 +1,119 @@
+---
+
+- name: Testing HAProxy Email Notifications
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_mailer'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing mailers
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test mailers (before)
+      ansibleguy.opnsense.haproxy_mailer:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_MAILER'
+        - 'ANSIBLE_TEST_2_MAILER'
+
+    - name: Add alert mailer (check)
+      ansibleguy.opnsense.haproxy_mailer:
+        name: 'ANSIBLE_TEST_1_MAILER'
+        description: 'Test alert mailer'
+        mailservers:
+          - 'mail.example.com:25'
+        sender: 'haproxy@example.com'
+        recipient: 'admin@example.com'
+      check_mode: true
+      register: opn_mailer1_check
+
+    - name: Add alert mailer
+      ansibleguy.opnsense.haproxy_mailer:
+        name: 'ANSIBLE_TEST_1_MAILER'
+        description: 'Test alert mailer'
+        mailservers:
+          - 'mail.example.com:25'
+        sender: 'haproxy@example.com'
+        recipient: 'admin@example.com'
+      register: opn_mailer1
+
+    - name: Verify mailer creation
+      ansibleguy.opnsense.list:
+      register: opn_mailer1_verify
+
+    - name: Add ops mailer with multiple servers
+      ansibleguy.opnsense.haproxy_mailer:
+        name: 'ANSIBLE_TEST_2_MAILER'
+        description: 'Test ops mailer'
+        mailservers:
+          - 'smtp.example.com:587'
+          - 'backup-smtp.example.com:587'
+        sender: 'alerts@example.com'
+        recipient: 'ops@example.com'
+      register: opn_mailer2
+
+    - name: Modify mailer 1 recipient
+      ansibleguy.opnsense.haproxy_mailer:
+        name: 'ANSIBLE_TEST_1_MAILER'
+        description: 'Modified test alert mailer'
+        mailservers:
+          - 'mail.example.com:25'
+          - 'backup-mail.example.com:25'
+        sender: 'haproxy@example.com'
+        recipient: 'newadmin@example.com'
+      register: opn_mailer1_changed
+
+    - name: Mailer 1 should not change (2)
+      ansibleguy.opnsense.haproxy_mailer:
+        name: 'ANSIBLE_TEST_1_MAILER'
+        description: 'Modified test alert mailer'
+        mailservers:
+          - 'mail.example.com:25'
+          - 'backup-mail.example.com:25'
+        sender: 'haproxy@example.com'
+        recipient: 'newadmin@example.com'
+      register: opn_mailer1_changed2
+
+    - name: Disable mailer 2
+      ansibleguy.opnsense.haproxy_mailer:
+        name: 'ANSIBLE_TEST_2_MAILER'
+        enabled: false
+      register: opn_mailer2_disabled
+
+    - name: Clean up test mailers (after)
+      ansibleguy.opnsense.haproxy_mailer:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_MAILER'
+        - 'ANSIBLE_TEST_2_MAILER'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_mailer1_check is changed
+          - opn_mailer1 is changed
+          - opn_mailer2 is changed
+          - opn_mailer1_changed is changed
+          - opn_mailer1_changed2 is not changed
+          - opn_mailer2_disabled is changed
+          - "opn_mailer1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_MAILER' in opn_mailer1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_MAILER' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy mailer tests failed!'

--- a/tests/haproxy_maintenance.yml
+++ b/tests/haproxy_maintenance.yml
@@ -1,0 +1,68 @@
+---
+
+- name: Testing HAProxy Maintenance Operations
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Get HAProxy maintenance information
+      ansibleguy.opnsense.haproxy_maintenance:
+        action: 'get'
+      register: opn_maintenance_info
+
+    - name: Search for servers
+      ansibleguy.opnsense.haproxy_maintenance:
+        action: 'search_server'
+      register: opn_search_servers
+
+    - name: Display maintenance info
+      ansible.builtin.debug:
+        var: opn_maintenance_info.result
+
+    - name: Display found servers
+      ansible.builtin.debug:
+        var: opn_search_servers.result
+
+    - name: Check certificate differences
+      ansibleguy.opnsense.haproxy_maintenance:
+        action: 'cert_diff'
+      register: opn_cert_diff
+
+    - name: Search for certificate differences
+      ansibleguy.opnsense.haproxy_maintenance:
+        action: 'search_certificate_diff'
+      register: opn_search_cert_diff
+
+    - name: Sync certificates
+      ansibleguy.opnsense.haproxy_maintenance:
+        action: 'cert_sync'
+      register: opn_cert_sync
+
+    - name: Fetch cron integration data
+      ansibleguy.opnsense.haproxy_maintenance:
+        action: 'fetch_cron_integration'
+      register: opn_cron_integration
+
+    # Note: Server state/weight tests would require actual servers to be configured
+    # These are basic functionality tests for the maintenance module
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_maintenance_info is not changed
+          - opn_search_servers is not changed
+          - opn_cert_diff is not changed
+          - opn_search_cert_diff is not changed
+          - opn_cert_sync is not failed
+          - opn_cron_integration is not changed
+          - opn_maintenance_info.result is defined
+          - opn_search_servers.result is defined
+        msg: 'HAProxy maintenance tests failed!'

--- a/tests/haproxy_mapfile.yml
+++ b/tests/haproxy_mapfile.yml
@@ -1,0 +1,114 @@
+---
+
+- name: Testing HAProxy Map Files
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_mapfile'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing map files
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test map files (before)
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_MAP'
+        - 'ANSIBLE_TEST_2_MAP'
+
+    - name: Add host mapping file (check)
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: 'ANSIBLE_TEST_1_MAP'
+        description: 'Test host mappings'
+        content: |
+          api.example.com api_backend
+          web.example.com web_backend
+      check_mode: true
+      register: opn_map1_check
+
+    - name: Add host mapping file
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: 'ANSIBLE_TEST_1_MAP'
+        description: 'Test host mappings'
+        content: |
+          api.example.com api_backend
+          web.example.com web_backend
+      register: opn_map1
+
+    - name: Verify map file creation
+      ansibleguy.opnsense.list:
+      register: opn_map1_verify
+
+    - name: Add path mapping file
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: 'ANSIBLE_TEST_2_MAP'
+        description: 'Test path mappings'
+        content: |
+          /api/ api_backend
+          /admin/ admin_backend
+          /static/ static_backend
+      register: opn_map2
+
+    - name: Modify map file 1 content
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: 'ANSIBLE_TEST_1_MAP'
+        description: 'Modified test host mappings'
+        content: |
+          api.example.com api_backend
+          web.example.com web_backend
+          admin.example.com admin_backend
+      register: opn_map1_changed
+
+    - name: Map file 1 should not change (2)
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: 'ANSIBLE_TEST_1_MAP'
+        description: 'Modified test host mappings'
+        content: |
+          api.example.com api_backend
+          web.example.com web_backend
+          admin.example.com admin_backend
+      register: opn_map1_changed2
+
+    - name: Disable map file 2
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: 'ANSIBLE_TEST_2_MAP'
+        enabled: false
+      register: opn_map2_disabled
+
+    - name: Clean up test map files (after)
+      ansibleguy.opnsense.haproxy_mapfile:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_MAP'
+        - 'ANSIBLE_TEST_2_MAP'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_map1_check is changed
+          - opn_map1 is changed
+          - opn_map2 is changed
+          - opn_map1_changed is changed
+          - opn_map1_changed2 is not changed
+          - opn_map2_disabled is changed
+          - "opn_map1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_MAP' in opn_map1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_MAP' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy map file tests failed!'

--- a/tests/haproxy_resolver.yml
+++ b/tests/haproxy_resolver.yml
@@ -1,0 +1,125 @@
+---
+
+- name: Testing HAProxy DNS Resolvers
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_resolver'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing resolvers
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test resolvers (before)
+      ansibleguy.opnsense.haproxy_resolver:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_RESOLVER'
+        - 'ANSIBLE_TEST_2_RESOLVER'
+
+    - name: Add custom DNS resolver (check)
+      ansibleguy.opnsense.haproxy_resolver:
+        name: 'ANSIBLE_TEST_1_RESOLVER'
+        description: 'Test custom DNS resolver'
+        nameservers:
+          - '8.8.8.8:53'
+          - '8.8.4.4:53'
+        parse_resolv_conf: false
+        resolve_retries: 3
+        timeout_resolve: '2s'
+      check_mode: true
+      register: opn_resolver1_check
+
+    - name: Add custom DNS resolver
+      ansibleguy.opnsense.haproxy_resolver:
+        name: 'ANSIBLE_TEST_1_RESOLVER'
+        description: 'Test custom DNS resolver'
+        nameservers:
+          - '8.8.8.8:53'
+          - '8.8.4.4:53'
+        parse_resolv_conf: false
+        resolve_retries: 3
+        timeout_resolve: '2s'
+      register: opn_resolver1
+
+    - name: Verify resolver creation
+      ansibleguy.opnsense.list:
+      register: opn_resolver1_verify
+
+    - name: Add system resolver
+      ansibleguy.opnsense.haproxy_resolver:
+        name: 'ANSIBLE_TEST_2_RESOLVER'
+        description: 'Test system resolver'
+        parse_resolv_conf: true
+        resolve_retries: 5
+        timeout_resolve: '1s'
+      register: opn_resolver2
+
+    - name: Modify resolver 1 timeout
+      ansibleguy.opnsense.haproxy_resolver:
+        name: 'ANSIBLE_TEST_1_RESOLVER'
+        description: 'Modified test custom DNS resolver'
+        nameservers:
+          - '8.8.8.8:53'
+          - '8.8.4.4:53'
+          - '1.1.1.1:53'
+        parse_resolv_conf: false
+        resolve_retries: 5
+        timeout_resolve: '3s'
+      register: opn_resolver1_changed
+
+    - name: Resolver 1 should not change (2)
+      ansibleguy.opnsense.haproxy_resolver:
+        name: 'ANSIBLE_TEST_1_RESOLVER'
+        description: 'Modified test custom DNS resolver'
+        nameservers:
+          - '8.8.8.8:53'
+          - '8.8.4.4:53'
+          - '1.1.1.1:53'
+        parse_resolv_conf: false
+        resolve_retries: 5
+        timeout_resolve: '3s'
+      register: opn_resolver1_changed2
+
+    - name: Disable resolver 2
+      ansibleguy.opnsense.haproxy_resolver:
+        name: 'ANSIBLE_TEST_2_RESOLVER'
+        enabled: false
+      register: opn_resolver2_disabled
+
+    - name: Clean up test resolvers (after)
+      ansibleguy.opnsense.haproxy_resolver:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_RESOLVER'
+        - 'ANSIBLE_TEST_2_RESOLVER'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_resolver1_check is changed
+          - opn_resolver1 is changed
+          - opn_resolver2 is changed
+          - opn_resolver1_changed is changed
+          - opn_resolver1_changed2 is not changed
+          - opn_resolver2_disabled is changed
+          - "opn_resolver1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_RESOLVER' in opn_resolver1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_RESOLVER' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy resolver tests failed!'

--- a/tests/haproxy_server.yml
+++ b/tests/haproxy_server.yml
@@ -1,0 +1,219 @@
+---
+
+- name: Testing HAProxy Backend Servers
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_server'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing servers
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test servers, resolvers, and frontends (before)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_SERVER'
+        - 'ANSIBLE_TEST_2_SERVER'
+        - 'ANSIBLE_TEST_3_SERVER'
+        - 'ANSIBLE_TEST_4_SERVER'
+
+    - name: Clean up test resolvers (before)
+      ansibleguy.opnsense.haproxy_resolver:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_RESOLVER_1'
+        - 'ANSIBLE_TEST_RESOLVER_2'
+
+    - name: Clean up test frontends (before)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_UNIX_FRONTEND'
+
+    - name: Create test resolvers for server linking
+      ansibleguy.opnsense.haproxy_resolver:
+        name: "{{ item.name }}"
+        description: "{{ item.desc }}"
+        nameserver: "{{ item.nameserver }}"
+        enabled: true
+      loop:
+        - { name: 'ANSIBLE_TEST_RESOLVER_1', desc: 'Test resolver 1', nameserver: '8.8.8.8:53' }
+        - { name: 'ANSIBLE_TEST_RESOLVER_2', desc: 'Test resolver 2', nameserver: '1.1.1.1:53' }
+
+    - name: Create test frontend for Unix socket linking
+      ansibleguy.opnsense.haproxy_frontend:
+        name: 'ANSIBLE_TEST_UNIX_FRONTEND'
+        description: 'Test Unix socket frontend'
+        bind_address: '/var/run/haproxy.sock'
+        bind_port: 80
+        mode: 'http'
+        enabled: true
+
+    - name: Add server (check)
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_1_SERVER'
+        description: 'Test server 1'
+        address: '192.168.1.10'
+        port: 80
+        weight: 10
+      check_mode: true
+      register: opn_server1_check
+
+    - name: Add server
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_1_SERVER'
+        description: 'Test server 1'
+        address: '192.168.1.10'
+        port: 80
+        weight: 10
+      register: opn_server1
+
+    - name: Verify server creation
+      ansibleguy.opnsense.list:
+      register: opn_server1_verify
+
+    - name: Add SSL server
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_2_SERVER'
+        description: 'Test SSL server'
+        address: 'api.example.com'
+        port: 443
+        ssl: true
+        ssl_verify: true
+        weight: 5
+        check_interval: '5s'
+      register: opn_server2
+
+    - name: Add database server
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_3_SERVER'
+        description: 'Test database server'
+        address: '10.0.0.5'
+        port: 5432
+        weight: 1
+        check_interval: '10s'
+        check_down_interval: '3s'
+        source: '10.0.0.100'
+      register: opn_server3
+
+    - name: Add server with name-based resolver linking
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_4_SERVER'
+        description: 'Test server with name-based resolver linking'
+        address: 'dynamic.example.com'
+        port: 8080
+        weight: 10
+        linked_resolver: 'ANSIBLE_TEST_RESOLVER_1'  # Test name-based resolver linking
+      register: opn_server4
+
+    - name: Modify server 1
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_1_SERVER'
+        description: 'Modified test server 1'
+        address: '192.168.1.10'
+        port: 8080
+        weight: 15
+        check_interval: '3s'
+      register: opn_server1_changed
+
+    - name: Server 1 should not change (2)
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_1_SERVER'
+        description: 'Modified test server 1'
+        address: '192.168.1.10'
+        port: 8080
+        weight: 15
+        check_interval: '3s'
+      register: opn_server1_changed2
+
+    - name: Update server 4 resolver (test changing resolver link)
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_4_SERVER'
+        linked_resolver: 'ANSIBLE_TEST_RESOLVER_2'  # Change to different resolver
+      register: opn_server4_resolver_changed
+
+    - name: Add Unix socket server with frontend linking
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_5_SERVER'
+        description: 'Test Unix socket server'
+        address: '/var/run/app.sock'
+        port: 80
+        weight: 5
+        unix_socket: 'ANSIBLE_TEST_UNIX_FRONTEND'  # Test name-based frontend linking
+      register: opn_server5
+
+    - name: Remove resolver link from server 4
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_4_SERVER'
+        linked_resolver: ''  # Clear resolver link
+      register: opn_server4_resolver_cleared
+
+    - name: Disable server 3
+      ansibleguy.opnsense.haproxy_server:
+        name: 'ANSIBLE_TEST_3_SERVER'
+        enabled: false
+      register: opn_server3_disabled
+
+    - name: Clean up test servers (after)
+      ansibleguy.opnsense.haproxy_server:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_SERVER'
+        - 'ANSIBLE_TEST_2_SERVER'
+        - 'ANSIBLE_TEST_3_SERVER'
+        - 'ANSIBLE_TEST_4_SERVER'
+        - 'ANSIBLE_TEST_5_SERVER'
+
+    - name: Clean up test resolvers (after)
+      ansibleguy.opnsense.haproxy_resolver:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_RESOLVER_1'
+        - 'ANSIBLE_TEST_RESOLVER_2'
+
+    - name: Clean up test frontends (after)
+      ansibleguy.opnsense.haproxy_frontend:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_UNIX_FRONTEND'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_server1_check is changed
+          - opn_server1 is changed
+          - opn_server2 is changed
+          - opn_server3 is changed
+          - opn_server4 is changed
+          - opn_server1_changed is changed
+          - opn_server1_changed2 is not changed
+          - opn_server4_resolver_changed is changed
+          - opn_server5 is changed
+          - opn_server4_resolver_cleared is changed
+          - opn_server3_disabled is changed
+          - "opn_server1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_SERVER' in opn_server1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_SERVER' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy server tests failed! Name-based resolver/frontend linking may not be working correctly.'

--- a/tests/haproxy_service.yml
+++ b/tests/haproxy_service.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Testing HAProxy Service Management
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Check HAProxy service status
+      ansibleguy.opnsense.haproxy_service:
+        action: status
+      register: opn_status1
+      failed_when: opn_status1.failed
+
+    - name: Test HAProxy configuration
+      ansibleguy.opnsense.haproxy_service:
+        action: configtest
+      register: opn_configtest1
+      failed_when: opn_configtest1.failed
+
+    - name: Stop HAProxy service
+      ansibleguy.opnsense.haproxy_service:
+        action: stop
+      register: opn_stop1
+      failed_when: opn_stop1.failed
+      when: not ansible_check_mode
+
+    - name: Start HAProxy service
+      ansibleguy.opnsense.haproxy_service:
+        action: start
+      register: opn_start1
+      failed_when: opn_start1.failed
+      when: not ansible_check_mode
+
+    - name: Reload HAProxy configuration
+      ansibleguy.opnsense.haproxy_service:
+        action: reload
+      register: opn_reload1
+      failed_when: opn_reload1.failed
+      when: not ansible_check_mode

--- a/tests/haproxy_statistics.yml
+++ b/tests/haproxy_statistics.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Testing HAProxy Statistics Retrieval
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Get HAProxy counters
+      ansibleguy.opnsense.haproxy_statistics:
+        stat_type: counters
+      register: haproxy_counters
+      failed_when: haproxy_counters.failed
+
+    - name: Get HAProxy info
+      ansibleguy.opnsense.haproxy_statistics:
+        stat_type: info
+      register: haproxy_info
+      failed_when: haproxy_info.failed
+
+    - name: Get HAProxy tables
+      ansibleguy.opnsense.haproxy_statistics:
+        stat_type: tables
+      register: haproxy_tables
+      failed_when: haproxy_tables.failed
+
+    - name: Show statistics results
+      ansible.builtin.debug:
+        msg: 
+          - "Counters: {{ haproxy_counters.statistics | default({}) }}"
+          - "Info: {{ haproxy_info.statistics | default({}) }}"
+          - "Tables: {{ haproxy_tables.statistics | default({}) }}"

--- a/tests/haproxy_user.yml
+++ b/tests/haproxy_user.yml
@@ -1,0 +1,106 @@
+---
+
+- name: Testing HAProxy User Management
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/ansibleguy.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    ansibleguy.opnsense.list:
+      target: 'haproxy_user'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: List existing users
+      ansibleguy.opnsense.list:
+      register: existing_entries
+
+    - name: Clean up test users (before)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_USER'
+        - 'ANSIBLE_TEST_2_USER'
+
+    - name: Add user (check)
+      ansibleguy.opnsense.haproxy_user:
+        name: 'ANSIBLE_TEST_1_USER'
+        description: 'Test user 1'
+        password: 'test_password_123'
+        enabled: true
+      check_mode: true
+      register: opn_user1_check
+
+    - name: Add user
+      ansibleguy.opnsense.haproxy_user:
+        name: 'ANSIBLE_TEST_1_USER'
+        description: 'Test user 1'
+        password: 'test_password_123'
+        enabled: true
+      register: opn_user1
+
+    - name: Verify user creation
+      ansibleguy.opnsense.list:
+      register: opn_user1_verify
+
+    - name: Add admin user
+      ansibleguy.opnsense.haproxy_user:
+        name: 'ANSIBLE_TEST_2_USER'
+        description: 'Test admin user'
+        password: 'admin_password_456'
+        enabled: true
+      register: opn_user2
+
+    - name: Modify user 1 description
+      ansibleguy.opnsense.haproxy_user:
+        name: 'ANSIBLE_TEST_1_USER'
+        description: 'Modified test user 1'
+        password: 'test_password_123'
+        enabled: true
+      register: opn_user1_changed
+
+    - name: User 1 should not change (2)
+      ansibleguy.opnsense.haproxy_user:
+        name: 'ANSIBLE_TEST_1_USER'
+        description: 'Modified test user 1'
+        password: 'test_password_123'
+        enabled: true
+      register: opn_user1_changed2
+
+    - name: Disable user 2
+      ansibleguy.opnsense.haproxy_user:
+        name: 'ANSIBLE_TEST_2_USER'
+        enabled: false
+      register: opn_user2_disabled
+
+    - name: Clean up test users (after)
+      ansibleguy.opnsense.haproxy_user:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_USER'
+        - 'ANSIBLE_TEST_2_USER'
+
+    - name: Verify cleanup
+      ansibleguy.opnsense.list:
+      register: opn_cleanup_verify
+
+    - name: Show test results
+      ansible.builtin.assert:
+        that:
+          - opn_user1_check is changed
+          - opn_user1 is changed
+          - opn_user2 is changed
+          - opn_user1_changed is changed
+          - opn_user1_changed2 is not changed
+          - opn_user2_disabled is changed
+          - "opn_user1_verify.data | length == (existing_entries.data | length + 1)"
+          - "'ANSIBLE_TEST_1_USER' in opn_user1_verify.data | map(attribute='name')"
+          - "'ANSIBLE_TEST_1_USER' not in opn_cleanup_verify.data | map(attribute='name')"
+        msg: 'HAProxy user tests failed!'


### PR DESCRIPTION
# Add HAProxy module support

## Summary

This PR adds comprehensive HAProxy module support to the ansible-opnsense collection with 20 complete modules

**20 HAProxy modules**: backend, frontend, server, action, acl, user, group, errorfile, general, service, statistics, maintenance, exporter, healthcheck, mapfile, resolver, mailer, lua, fcgi, cpu

Close https://github.com/O-X-L/ansible-opnsense/issues/68