### PR TITLE
Allow for dynamic gateways (fix #271)

### DIFF
--- a/docs/source/modules/route.rst
+++ b/docs/source/modules/route.rst
@@ -62,6 +62,7 @@ ansibleguy.opnsense.gateway
 
     "name","string","true","\-","\-","Gateway Name"
     "interface","string","true","\-","int, if","Interface belonging to this gateway"
+    "ip_protocol","string","false","\-","\-","Internet Protocol this gateway uses. Possible options: ['inet', 'inet6']. Required if no gateway is set."
     "gateway","string","true","\-","gw, ip","Gateway IP"
     "description","string","false","\-","desc","Optional description for the Gateway. Could be used as unique-identifier when set as only 'match_field'."
     "default_gw","string","true","\-","default, internet, inet","This will select the above gateway as a default gateway candidate."

--- a/plugins/module_utils/main/gateway.py
+++ b/plugins/module_utils/main/gateway.py
@@ -4,6 +4,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.validate import \
     is_ip6
+from ansible_collections.ansibleguy.opnsense.plugins.module_utils.helper.main import is_unset
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.api import \
     Session
 from ansible_collections.ansibleguy.opnsense.plugins.module_utils.base.cls import BaseModule
@@ -67,11 +68,12 @@ class Gw(BaseModule):
 
     def check(self) -> None:
         if self.p['state'] == 'present':
-            try:
-                ip_address(self.p['gateway'])
+            if not is_unset(self.p['gateway']):
+                try:
+                    ip_address(self.p['gateway'])
 
-            except ValueError:
-                self.m.fail_json(f"Value '{self.p['gateway']}' is not a valid gateway!")
+                except ValueError:
+                    self.m.fail_json(f"Value '{self.p['gateway']}' is not a valid gateway!")
 
             if self.p['monitor']:
                 try:
@@ -86,10 +88,11 @@ class Gw(BaseModule):
             if not self.p['gateway']:
                 self.m.fail_json('You need to provide a value for the gateway!')
 
-            if is_ip6(self.p['gateway']):
-                self.p['ip_protocol'] = 'inet6'
+            if is_unset(self.p['ip_protocol']):
+                if is_ip6(self.p['gateway']):
+                    self.p['ip_protocol'] = 'inet6'
 
-            else:
-                self.p['ip_protocol'] = 'inet'
+                else:
+                    self.p['ip_protocol'] = 'inet'
 
         self._base_check()

--- a/plugins/modules/gateway.py
+++ b/plugins/modules/gateway.py
@@ -35,6 +35,10 @@ def run_module():
             type='str', required=False, aliases=['int', 'if'],
             description='Interface for Gateway'
         ),
+        ip_protocol=dict(
+            type='str', required=False, choices=['inet', 'inet6'],
+            description='The Internet Protocol this gateway uses.',
+        ),
         gateway=dict(
             type='str', required=False, aliases=['gw', 'ip'],
             description='Gateway IP'
@@ -140,6 +144,9 @@ def run_module():
     module = AnsibleModule(
         argument_spec=module_args,
         supports_check_mode=True,
+        required_if=[
+            ('state', 'present', ('gateway', 'ip_protocol'), True),
+        ],
     )
 
     module_wrapper(Gw(module=module, result=result))

--- a/tests/gateway.yml
+++ b/tests/gateway.yml
@@ -34,6 +34,14 @@
         opn3.failed or
         opn3.changed
 
+    - name: Adding 1 - failing because of invalid gateway
+      ansibleguy.opnsense.gateway:
+        name: 'ANSIBLE_TEST_1'
+        interface: 'lan'
+        gateway: 999.999.999.999
+      register: opn_fail1
+      failed_when: not opn_fail1.failed
+
     - name: Adding 1
       ansibleguy.opnsense.gateway:
         name: 'ANSIBLE_TEST_1'


### PR DESCRIPTION
Allow to create/modify gateways without a static gateway.

Added a (optional) new parameter `ip_protocol`, as it can not always be deduced from the gateway address any more.

Work on my test set-up, however I do not like to add a unit test as this requires in interface without a static ip assignment. And this would change the requirements for the interfaces. See: https://github.com/O-X-L/ansible-opnsense/blob/7935f2e7d18ca608b021947cd918dec303d248f1/tests/README.md?plain=1#L34C56-L34C87