### PR TITLE
fix: set alias updatefreq_days default to none

### DIFF
--- a/docs/source/modules/alias.rst
+++ b/docs/source/modules/alias.rst
@@ -46,7 +46,7 @@ Definition
     "description","string","false","\-","desc","Description for the alias"
     "content","list","false for state changes, else true","\-","cont, c","Values the alias should hold"
     "type","string","false","'host'","t","Type of value the alias should hold. One of: 'host', 'network', 'port', 'url', 'urltable', 'geoip', 'networkgroup', 'mac', 'dynipv6host', 'internal', 'external'"
-    "updatefreq_days","float","false","7.0","\-","Needed only for the alias-type 'urltable'. Interval to update its content. Per example: 0.5 for every 12 hours"
+    "updatefreq_days","float","false","7.0 if type=urltable","\-","Needed only for the alias-type 'urltable'. Interval to update its content. Per example: 0.5 for every 12 hours"
     "interface","string","false","\-","int, if","Needed only for the alias-type 'dynipv6host'. Select the interface for the V6 dynamic IP"
     "reload","boolean","false","false","\-", .. include:: ../_include/param_reload.rst
 

--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -8,7 +8,7 @@ ALIAS_DEFAULTS = {
     'type': 'host',
     'content': [],
     'debug': False,
-    'updatefreq_days': 7.0,
+    'updatefreq_days': '',
     'interface': None
 }
 
@@ -37,7 +37,7 @@ ALIAS_MOD_ARGS = dict(
         'mac', 'dynipv6host', 'internal', 'external',
     ], default=ALIAS_DEFAULTS['type'], aliases=ALIAS_MOD_ARG_ALIASES['type']),
     updatefreq_days=dict(
-        type='float', default=ALIAS_DEFAULTS['updatefreq_days'], required=False,
+        type='str', default=ALIAS_DEFAULTS['updatefreq_days'], required=False,
         description="Update frequency used by type 'urltable' in days - "
                     "per example '0.5' for 12 hours"
     ),

--- a/plugins/module_utils/defaults/main.py
+++ b/plugins/module_utils/defaults/main.py
@@ -54,7 +54,7 @@ OPN_MOD_ARGS = dict(
 )
 
 BUILTIN_ALIASES = [
-    'bogons', 'bogonsv6', 'sshlockout', 'virusprot',
+    'bogons', 'bogonsv6', 'sshlockout', 'virusprot', '__wazuh_agent_drop',
 ]
 BUILTIN_INTERFACE_ALIASES_REG = '^__.*?_network$'  # auto-added interface aliases
 

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -39,6 +39,8 @@ class Alias(BaseModule):
     TIMEOUT = 20.0
     MAX_ALIAS_LEN = 32
 
+    DEFAULT_UPDATEFREQ_DAYS_URLTABLE = 7.0  # see: https://github.com/O-X-L/ansible-opnsense/pull/270
+
     def __init__(
             self, module: AnsibleModule, result: dict, cnf: dict = None,
             session: Session = None, fail_verify: bool = True, fail_proc: bool = True
@@ -54,6 +56,9 @@ class Alias(BaseModule):
             self.FIELDS_CHANGE = self.FIELDS_CHANGE + ['updatefreq_days']
             if not is_unset(self.p['updatefreq_days']):
                 self.p['updatefreq_days'] = float(self.p['updatefreq_days'])
+
+            else:
+                self.p['updatefreq_days'] = self.DEFAULT_UPDATEFREQ_DAYS_URLTABLE
 
         if self.p['type'] == 'dynipv6host':
             if is_unset(self.p['interface']):


### PR DESCRIPTION
Setting the updatefreq_days of aliases to none (except for urltable-types) as mentioned in #270