### PR TITLE
Fearute: Add urljson suport alias.

### DIFF
--- a/docs/source/modules/alias.rst
+++ b/docs/source/modules/alias.rst
@@ -45,9 +45,10 @@ Definition
     "name","string","true","\-","n","Unique name of the alias"
     "description","string","false","\-","desc","Description for the alias"
     "content","list","false for state changes, else true","\-","cont, c","Values the alias should hold"
-    "type","string","false","'host'","t","Type of value the alias should hold. One of: 'host', 'network', 'port', 'url', 'urltable', 'geoip', 'networkgroup', 'mac', 'dynipv6host', 'internal', 'external'"
-    "updatefreq_days","float","false","7.0 if type=urltable","\-","Needed only for the alias-type 'urltable'. Interval to update its content. Per example: 0.5 for every 12 hours"
+    "type","string","false","'host'","t","Type of value the alias should hold. One of: 'host', 'network', 'port', 'url', 'urltable', 'urljson', 'geoip', 'networkgroup', 'mac', 'dynipv6host', 'internal', 'external'"
+    "updatefreq_days","float","false","7.0 if type=urltable","\-","Needed only for the alias-type 'urltable' or 'urljson'. Interval to update its content. Per example: 0.5 for every 12 hours"
     "interface","string","false","\-","int, if","Needed only for the alias-type 'dynipv6host'. Select the interface for the V6 dynamic IP"
+    "path_expression","string","false","\-","pr, jq","Needed only for the alias-type 'urljson'. Simplified expression to select a field inside a container, a dot is used as field separator (e.g. container.fieldname). Expressions using the jq language are also supported."
     "reload","boolean","false","false","\-", .. include:: ../_include/param_reload.rst
 
 .. include:: ../_include/param_basic.rst
@@ -80,8 +81,9 @@ Examples
             content: '1.1.1.1'
             state: 'present'
             # type: 'host'  # default
-            # updatefreq_days: 3  # used only for type 'urltable'
+            # updatefreq_days: 3  # used only for type 'urltable' and 'urljson'
             # interface: lan # used only for the type 'dynipv6host'
+            # path_expression: # used only for type 'urljson'
             # ssl_ca_file: '/etc/ssl/certs/custom/ca.crt'
             # ssl_verify: False
             # api_key: !vault ...  # alternative to 'api_credential_file'
@@ -130,13 +132,19 @@ Examples
             updatefreq_days: 2.6
             content: 'https://www.spamhaus.org/drop/drop.txt'
 
-        - name: Adding dns-names
+        - name: Adding url-json
           ansibleguy.opnsense.alias:
             name: 'ANSIBLE_TEST5'
+            type: 'urltable'
+            updatefreq_days: 2.6
+            content: 'https://www.spamhaus.org/drop/drop.txt'
+
+        - name: Adding dns-names
+          ansibleguy.opnsense.alias:
+            name: 'ANSIBLE_TEST6'
             content:
-              - 'acme-v02.api.letsencrypt.org'
-              - 'staging-v02.api.letsencrypt.org'
-              - 'r3.o.lencr.org'
+              - 'https://api.github.com/meta'
+            path_expression: '.web + .api + .git | .[]'
 
         - name: Adding network
           ansibleguy.opnsense.alias:

--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -9,7 +9,8 @@ ALIAS_DEFAULTS = {
     'content': [],
     'debug': False,
     'updatefreq_days': '',
-    'interface': None
+    'interface': None,
+    'path_expression': '',
 }
 
 ALIAS_MOD_ARG_ALIASES = {
@@ -19,7 +20,8 @@ ALIAS_MOD_ARG_ALIASES = {
     'description': ['desc'],
     'state': ['st'],
     'enabled': ['en'],
-    'interface': ['int', 'if']
+    'interface': ['int', 'if'],
+    'path_expression': ['pe', 'jq'],
 }
 
 ALIAS_MOD_ARGS = dict(
@@ -45,6 +47,12 @@ ALIAS_MOD_ARGS = dict(
         type='str', default=ALIAS_DEFAULTS['interface'],
         aliases=ALIAS_MOD_ARG_ALIASES['interface'], required=False,
         description=' Select the interface for the V6 dynamic IP.',
+    ),
+    path_expression=dict(
+        type='str', default=ALIAS_DEFAULTS['path_expression'],
+        aliases=ALIAS_MOD_ARG_ALIASES['path_expression'], required=False,
+        description='Simplified expression to select a field inside a container, a dot is used as field separator. '
+                    'Expressions using the jq language are also supported.',
     ),
     **STATE_MOD_ARG,
     **OPN_MOD_ARGS,

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -26,7 +26,7 @@ class Alias(BaseModule):
     FIELDS_CHANGE = ['content', 'description']
     FIELDS_ALL = ['name', 'type', 'enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)
-    FIELDS_ALL.extend(['updatefreq_days', 'interface'])
+    FIELDS_ALL.extend(['updatefreq_days', 'interface', 'path_expression'])
     FIELDS_TRANSLATE = {
         'updatefreq_days': 'updatefreq',
     }
@@ -59,6 +59,11 @@ class Alias(BaseModule):
 
             else:
                 self.p['updatefreq_days'] = self.DEFAULT_UPDATEFREQ_DAYS_URLTABLE
+
+        if self.p['type'] == 'urljson':
+            self.FIELDS_CHANGE = self.FIELDS_CHANGE + ['updatefreq_days', 'path_expression']
+            if not is_unset(self.p['updatefreq_days']):
+                self.p['updatefreq_days'] = float(self.p['updatefreq_days'])
 
         if self.p['type'] == 'dynipv6host':
             if is_unset(self.p['interface']):
@@ -98,7 +103,7 @@ class Alias(BaseModule):
             **simple,
         }
 
-        if simple['type'] == 'urltable':
+        if simple['type'] in ['urltable', 'urljson']:
             try:
                 simple['updatefreq_days'] = round(float(alias['updatefreq']), 1)
 

--- a/tests/alias.yml
+++ b/tests/alias.yml
@@ -357,6 +357,29 @@
         - ['httks://test.ansibleguy.net']
         #        - ['https://ansibleguy.net']  # not an urltable
 
+    # urljson
+
+    - name: Adding urljson
+      ansibleguy.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_URLJSON1'
+        type: 'urltable'
+        updatefreq_days: 2
+        content: 'https://api.github.com/meta'
+        path_expression: .web + .api + .git | .[]
+
+    - name: Adding urljson - nothing changed
+      ansibleguy.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_URLJSON1'
+        type: 'urltable'
+        updatefreq_days: 2
+        content: 'https://api.github.com/meta'
+        path_expression: .web + .api + .git | .[]
+      register: opn16
+      failed_when: >
+        opn16.failed or
+        opn16.changed
+      when: not ansible_check_mode
+
     # geoip
 
     - name: Adding geoip
@@ -401,6 +424,7 @@
         state: 'absent'
       diff: false
       loop:
+        - 'ANSIBLE_TEST_1_2_URLJSON1'
         - 'ANSIBLE_TEST_1_2_URLTABLE3'
         - 'ANSIBLE_TEST_1_2_URLTABLE2'
         - 'ANSIBLE_TEST_1_2_URLTABLE1'


### PR DESCRIPTION
Add support for the `urljson` alias type introduced in OPNsense 25.1.

https://docs.opnsense.org/manual/aliases.html#url-table-in-json-format-ips