### PR TITLE
Multi-Handling: Delayed validation & validation-warnings

### DIFF
--- a/plugins/module_utils/base/multi.py
+++ b/plugins/module_utils/base/multi.py
@@ -65,7 +65,7 @@ def build_multi_mod_args(
         multi=dict(
             type='list', required=False, default=[], aliases=aliases,
             description=description,
-            elements='dict', options=entry_args_full,
+            elements='dict', options_late=entry_args_full,
         ),
         multi_purge=dict(
             type='list', required=False, default=[], aliases=aliases_purge,
@@ -308,6 +308,7 @@ class MultiModule:
             error_func = self.m.warn
 
         validation = ModuleArgumentSpecValidator(self.mod_entry_args).validate(parameters=entry)
+        entry.update(validation.validated_parameters)
 
         try:
             validation_error = validation.errors[0]
@@ -358,18 +359,16 @@ class MultiModule:
                 if f not in entry:
                     entry[f] = self.p[f]
 
-            entry = self.callbacks.build(entry)
-
-            if not self.validation:
-                valid_entries.append(entry)
-
-            else:
-                # (re-)validate the entry like ansible does on module-init
+            if self.validation:
+                # validate the entry like ansible does on module-init
                 if entry['debug']:
                     self.m.warn(f"Validating {self.k}: '{entry}'")
 
-                if self._validate_entry(entry):
-                    valid_entries.append(entry)
+                if not self._validate_entry(entry):
+                    continue
+
+            entry = self.callbacks.build(entry)
+            valid_entries.append(entry)
 
         return valid_entries
 

--- a/plugins/module_utils/base/multi.py
+++ b/plugins/module_utils/base/multi.py
@@ -57,7 +57,7 @@ def build_multi_mod_args(
     not_required.append('match_fields')
     for field in not_required:
         if field in args_base:
-            args_base[field]['required'] = False
+            mod_args[field] = {**mod_args[field], 'required': False}
 
     entry_args_full = {**args_base, **RELOAD_MOD_ARG_DEF_FALSE, **opn_args_multi}
 

--- a/plugins/module_utils/base/multi_base_1_mod_args_pytest.py
+++ b/plugins/module_utils/base/multi_base_1_mod_args_pytest.py
@@ -42,3 +42,6 @@ def test_build_multi_mod_args():
     mo = a['multi']['options_late']
     for k in OPN_MOD_ARGS:
         assert k in mo
+
+    assert mod_args['arg2']['required'] is False
+    assert a['multi']['options_late']['arg2']['required'] is True

--- a/plugins/module_utils/base/multi_base_1_mod_args_pytest.py
+++ b/plugins/module_utils/base/multi_base_1_mod_args_pytest.py
@@ -39,6 +39,6 @@ def test_build_multi_mod_args():
     assert 'purge_filter_partial' in mc
     assert 'purge_all' in mc
 
-    mo = a['multi']['options']
+    mo = a['multi']['options_late']
     for k in OPN_MOD_ARGS:
         assert k in mo

--- a/plugins/module_utils/base/multi_base_2_parts_pytest.py
+++ b/plugins/module_utils/base/multi_base_2_parts_pytest.py
@@ -54,6 +54,9 @@ def test_build_multi_mod_args():
     for k in OPN_MOD_ARGS:
         assert k in mo
 
+    assert mod_args['arg2']['required'] is False
+    assert a['multi']['options_late']['arg2']['required'] is True
+
 
 @pytest.mark.parametrize('params, result', [
     (

--- a/plugins/module_utils/base/multi_base_2_parts_pytest.py
+++ b/plugins/module_utils/base/multi_base_2_parts_pytest.py
@@ -50,7 +50,7 @@ def test_build_multi_mod_args():
     assert 'purge_filter_partial' in mc
     assert 'purge_all' in mc
 
-    mo = a['multi']['options']
+    mo = a['multi']['options_late']
     for k in OPN_MOD_ARGS:
         assert k in mo
 

--- a/plugins/module_utils/base/wrapper.py
+++ b/plugins/module_utils/base/wrapper.py
@@ -38,7 +38,7 @@ def module_multi_wrapper(
         result=result,
         kind=kind,
         obj=obj,
-        entry_args=entry_args['multi']['options'],
+        entry_args=entry_args['multi']['options_late'],
         callbacks=callbacks,
     )
     if module.params['profiling'] or module.params['debug']:


### PR DESCRIPTION
Using the Mass Management abstractions the entries of the multi parameter get validated twice. Once at Module initialisation and later one by one in `_build_entries` 

https://github.com/O-X-L/ansible-opnsense/blob/4512b799e362649a632849ad25525d33c84d5a5a/plugins/module_utils/base/multi.py#L371-L372

If a parameter of a entry is set by using an alias the first validation resolves this. The parametre is not set as both the actual name and the alias. When revalidating later the validation warns about this

```
TASK [Adding 1 and 2] *********************************************************************************************************************************************************
[WARNING]: Both option local and its alias local_addr are set.
[WARNING]: Both option remote and its alias remote_addr are set.
[WARNING]: Both option tunnel_local and its alias tunnel_local_addr are set.
[WARNING]: Both option tunnel_remote and its alias tunnel_remote_addr are set.
[WARNING]: Processing interface_gre: 'ANSIBLE_TEST_2_1'
[WARNING]: Processing interface_gre: 'ANSIBLE_TEST_2_2'
changed: [localhost]
```

The revalidation is necessary, as in _build_entries the entries are combined with the override. However the first validation is not. Infect it may even by problematic. For example with `bind_record` it would be feasable to provide the domain for a while list of entries as an override. This currently only works as the `build_multi_mod_args` removes the required from both domain and name.

As the entries in multi are not validated during the module initialisation the require for the domain and name can be left in place for the entries. It only need to be removed for the main arguments as the can be absent if on of the multi parameters is set.