### PR TITLE
fix: gateway ip should not be required

### DIFF
--- a/plugins/module_utils/main/gateway.py
+++ b/plugins/module_utils/main/gateway.py
@@ -86,9 +86,6 @@ class Gw(BaseModule):
             if not self.p['interface']:
                 self.m.fail_json('You need to provide a value for the interface!')
 
-            if not self.p['gateway']:
-                self.m.fail_json('You need to provide a value for the gateway!')
-
             if is_unset(self.p['ip_protocol']):
                 if is_ip6(self.p['gateway']):
                     self.p['ip_protocol'] = 'inet6'

--- a/plugins/module_utils/main/gateway.py
+++ b/plugins/module_utils/main/gateway.py
@@ -86,10 +86,9 @@ class Gw(BaseModule):
             if not self.p['interface']:
                 self.m.fail_json('You need to provide a value for the interface!')
 
-            if is_unset(self.p['ip_protocol']):
+            if is_unset(self.p['ip_protocol']) and not is_unset(self.p['gateway']):
                 if is_ip6(self.p['gateway']):
                     self.p['ip_protocol'] = 'inet6'
-
                 else:
                     self.p['ip_protocol'] = 'inet'
 

--- a/plugins/module_utils/main/gateway.py
+++ b/plugins/module_utils/main/gateway.py
@@ -86,10 +86,4 @@ class Gw(BaseModule):
             if not self.p['interface']:
                 self.m.fail_json('You need to provide a value for the interface!')
 
-            if is_unset(self.p['ip_protocol']) and not is_unset(self.p['gateway']):
-                if is_ip6(self.p['gateway']):
-                    self.p['ip_protocol'] = 'inet6'
-                else:
-                    self.p['ip_protocol'] = 'inet'
-
         self._base_check()

--- a/plugins/module_utils/main/gateway.py
+++ b/plugins/module_utils/main/gateway.py
@@ -3,7 +3,7 @@ from ipaddress import ip_address
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.validate import \
-    is_ip6
+    is_ip4, is_ip6
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.main import is_unset
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import \
     Session
@@ -75,6 +75,11 @@ class Gw(BaseModule):
 
                 except ValueError:
                     self.m.fail_json(f"Value '{self.p['gateway']}' is not a valid gateway!")
+
+                if self.p['ip_protocol'] == 'inet' and not is_ip4(self.p['gateway']):
+                    self.m.fail_json(f"Gateway '{self.p['gateway']}' is not a valid IPv4-address!")
+                elif self.p['ip_protocol'] == 'inet6' and not is_ip6(self.p['gateway']):
+                    self.m.fail_json(f"Gateway '{self.p['gateway']}' is not a valid IPv6-address!")
 
             if self.p['monitor']:
                 try:

--- a/plugins/modules/gateway.py
+++ b/plugins/modules/gateway.py
@@ -38,6 +38,7 @@ def run_module():
         ip_protocol=dict(
             type='str', required=False, choices=['inet', 'inet6'],
             description='The Internet Protocol this gateway uses.',
+            default='inet'
         ),
         gateway=dict(
             type='str', required=False, aliases=['gw', 'ip'],


### PR DESCRIPTION
it is an optional field in the UI
<img width="649" height="461" alt="image" src="https://github.com/user-attachments/assets/7fcb0c87-a24c-40f6-933e-7aab0337d2bc" />

other changes:
- default ip_protocol to inet (ipv4)
  - also removes determining ip_protocol if not provided but gateway is provided
- check if gateway is a valid ip address if provided
