### PR TITLE
fix: dnsmasq reload

### DIFF
--- a/plugins/module_utils/main/dnsmasq_boot.py
+++ b/plugins/module_utils/main/dnsmasq_boot.py
@@ -17,6 +17,7 @@ class Boot(BaseModule):
     API_KEY_PATH_REQ = 'boot'
     API_MOD = 'dnsmasq'
     API_CONT = 'settings'
+    API_CONT_REL = 'service'
     FIELDS_CHANGE = ['address', 'filename', 'interface', 'servername', 'tag']
     FIELDS_TYPING = {
         'select': ['interface'],

--- a/plugins/module_utils/main/dnsmasq_domain.py
+++ b/plugins/module_utils/main/dnsmasq_domain.py
@@ -17,6 +17,7 @@ class Domain(BaseModule):
     API_KEY_PATH_REQ = 'domainoverride'
     API_MOD = 'dnsmasq'
     API_CONT = 'settings'
+    API_CONT_REL = 'service'
     FIELDS_CHANGE = ['sequence', 'ipset', 'src_ip', 'port', 'ip', 'description']
     FIELDS_TRANSLATE = {
         'description': 'descr',

--- a/plugins/module_utils/main/dnsmasq_host.py
+++ b/plugins/module_utils/main/dnsmasq_host.py
@@ -21,6 +21,7 @@ class Host(BaseModule):
     API_KEY_PATH_REQ = 'host'
     API_MOD = 'dnsmasq'
     API_CONT = 'settings'
+    API_CONT_REL = 'service'
     FIELDS_CHANGE = [
         'host', 'domain', 'local', 'ip', 'aliases', 'cnames', 'client_id', 'hardware_addr', 'lease_time', 'ignore',
         'set_tag', 'comments',

--- a/plugins/module_utils/main/dnsmasq_option.py
+++ b/plugins/module_utils/main/dnsmasq_option.py
@@ -19,6 +19,7 @@ class Option(BaseModule):
     API_KEY_PATH_REQ = 'option'
     API_MOD = 'dnsmasq'
     API_CONT = 'settings'
+    API_CONT_REL = 'service'
     FIELDS_CHANGE = ['type', 'option', 'option6', 'interface', 'tag', 'set_tag', 'value', 'force']
     FIELDS_TYPING = {
         'select': ['type', 'option', 'option6', 'interface', 'set_tag'],

--- a/plugins/module_utils/main/dnsmasq_range.py
+++ b/plugins/module_utils/main/dnsmasq_range.py
@@ -19,6 +19,7 @@ class Range(BaseModule):
     API_KEY_PATH_REQ = 'range'
     API_MOD = 'dnsmasq'
     API_CONT = 'settings'
+    API_CONT_REL = 'service'
     FIELDS_CHANGE = [
         'interface', 'set_tag', 'start_addr', 'end_addr', 'subnet_mask', 'constructor', 'mode',
         'prefix_len', 'lease_time', 'domain_type', 'domain', 'sync', 'ra_mode', 'ra_priority',

--- a/plugins/module_utils/main/dnsmasq_tag.py
+++ b/plugins/module_utils/main/dnsmasq_tag.py
@@ -16,6 +16,7 @@ class Tag(BaseModule):
     API_KEY_PATH_REQ = 'tag'
     API_MOD = 'dnsmasq'
     API_CONT = 'settings'
+    API_CONT_REL = 'service'
     FIELDS_CHANGE = []
     FIELDS_TYPING = {}
     FIELDS_ALL = ['tag']

--- a/plugins/modules/dnsmasq_boot.py
+++ b/plugins/modules/dnsmasq_boot.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_boot import Boot
 
 except MODULE_EXCEPTIONS:
@@ -52,6 +52,7 @@ def run_module():
             description='DHCP boot server address.',
         ),
         **STATE_ONLY_MOD_ARG,
+        **RELOAD_MOD_ARG,
         **OPN_MOD_ARGS,
     )
 

--- a/plugins/modules/dnsmasq_domain.py
+++ b/plugins/modules/dnsmasq_domain.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_domain import Domain
 
 except MODULE_EXCEPTIONS:
@@ -56,6 +56,7 @@ def run_module():
             description='Description here for your reference.',
         ),
         **STATE_ONLY_MOD_ARG,
+        **RELOAD_MOD_ARG,
         **OPN_MOD_ARGS,
     )
 

--- a/plugins/modules/dnsmasq_host.py
+++ b/plugins/modules/dnsmasq_host.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_host import Host
 
 except MODULE_EXCEPTIONS:
@@ -81,6 +81,7 @@ def run_module():
             description='A comment for your reference (not parsed).',
         ),
         **STATE_ONLY_MOD_ARG,
+        **RELOAD_MOD_ARG,
         **OPN_MOD_ARGS,
     )
 

--- a/plugins/modules/dnsmasq_option.py
+++ b/plugins/modules/dnsmasq_option.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_option import Option
 
 except MODULE_EXCEPTIONS:
@@ -66,6 +66,7 @@ def run_module():
             description='Always send the option, also when the client does not ask for it.',
         ),
         **STATE_ONLY_MOD_ARG,
+        **RELOAD_MOD_ARG,
         **OPN_MOD_ARGS,
     )
 

--- a/plugins/modules/dnsmasq_range.py
+++ b/plugins/modules/dnsmasq_range.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_range import Range
 
 except MODULE_EXCEPTIONS:
@@ -101,6 +101,7 @@ def run_module():
             description='Lifetime of the route.',
         ),
         **STATE_ONLY_MOD_ARG,
+        **RELOAD_MOD_ARG,
         **OPN_MOD_ARGS,
     )
 

--- a/plugins/modules/dnsmasq_tag.py
+++ b/plugins/modules/dnsmasq_tag.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_tag import Tag
 
 except MODULE_EXCEPTIONS:
@@ -32,6 +32,7 @@ def run_module():
             description='DHCP tag.',
         ),
         **STATE_ONLY_MOD_ARG,
+        **RELOAD_MOD_ARG,
         **OPN_MOD_ARGS,
     )
 

--- a/plugins/modules/reload.py
+++ b/plugins/modules/reload.py
@@ -51,8 +51,7 @@ def run_module():
                 'openvpn',
                 'dhcrelay',
                 'dhcp', 'kea',
-                'dnsmasq'
-
+                'dnsmasq',
             ],
             description='What part of the running config should be reloaded'
         ),
@@ -171,7 +170,7 @@ def run_module():
 
         elif target in ['dnsmasq']:
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.dnsmasq_general import \
-                Dnsmasq as Target_Obj
+                General as Target_Obj
 
     except MODULE_EXCEPTIONS:
         module_dependency_error()


### PR DESCRIPTION
Fixes reload not working for the dnsmasq service

1. Incorrect class was imported in reload.py
1. reload was not configured for any of the dnsmasq modules other than `dnsmasq_general`