### PR TITLE
wireguard_server: public key not required

### DIFF
--- a/plugins/module_utils/main/wireguard_server.py
+++ b/plugins/module_utils/main/wireguard_server.py
@@ -73,9 +73,9 @@ class Server(BaseModule):
                     f"Gateway '{self.p['gateway']}' is not a valid IP-address!"
                 )
 
-            if is_unset(self.p['private_key']) or is_unset(self.p['public_key']):
+            if is_unset(self.p['private_key']):
                 self.m.fail_json(
-                    "You need to provide a 'public_key' and 'private_key'!"
+                    "You need to provide a 'private_key'!"
                 )
 
         link_peers = not is_unset(self.p['peers']) or self.p['link_peers']

--- a/tests/wireguard_server.yml
+++ b/tests/wireguard_server.yml
@@ -85,14 +85,6 @@
       register: opn19
       failed_when: not opn19.failed
 
-    - name: Adding 1 - failing because of missing pub
-      oxlorg.opnsense.wireguard_server:
-        name: 'ANSIBLE_TEST_1_1'
-        allowed_ips: ['192.168.0.1/32']
-        private_key: "{{ test.priv1 }}"
-      register: opn20
-      failed_when: not opn20.failed
-
     - name: Adding 1 - failing because of non-existent CARP-VIP
       oxlorg.opnsense.wireguard_server:
         name: 'ANSIBLE_TEST_1_1'


### PR DESCRIPTION
providing a public key for a wireguard instance/server isn't required anymore