### PR TITLE
feat: v25.7.8 unbound_dnsbl migration

### DIFF
--- a/docs/source/modules/unbound_dnsbl.rst
+++ b/docs/source/modules/unbound_dnsbl.rst
@@ -17,7 +17,14 @@ DNS - Unbound - Blocklists
 Contribution
 ************
 
-Thanks to `@jiuka <https://github.com/jiuka>`_ for developing this module!
+Thanks to `@jiuka <https://github.com/jiuka>`_ and `@Rath <https://github.com/superstes>`_ for developing this module!
+
+----
+
+.. warning::
+
+    You need to run OPNsense version >= 25.7.8 to be able to have multiple DNS-blocklists.
+
 
 ----
 
@@ -28,29 +35,18 @@ Definition
     :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
     :widths: 15 10 10 10 10 45
 
-    "safesearch","boolean","false","false","\-","Force the usage of SafeSearch on Google, DuckDuckGo, Bing, Qwant, PixaBay and YouTube"
-    "type","list of strings","false","[]","\-","Select which kind of DNSBL you want to use"
-    "whitelists","list of strings","false","[]","whitelist, allowlist, allowlists","List of domains to whitelist. You can use regular expressions"
-    "blocklists","list of strings","false","[]","blocklist","List of domains to blocklist. Only exact matches are supported"
-    "wildcards","list of strings","false","[]","wildcard","List of wildcard domains to blocklist. All subdomains of the given domain will be blocked. Blocking first-level domains is not supported"
-    "address","strings","false","\-","\-","Destination ip address for entries in the blocklist (leave empty to use default: 0.0.0.0). Not used when 'Return NXDOMAIN' is checked"
-
-..  csv-table:: Definition
-    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
-    :widths: 15 10 10 10 10 45
-
+    "name","string","true","false","description,desc","Unique name to identify the entry"
+    "providers","list of strings","false","[]","type,dnsbl,bl","Select which kind of DNSBL you want to use"
+    "download_urls","list of strings","false","[]","download,lists","List of URLs/domains from where blocklist will be downloaded"
+    "domains_allow","list of strings","false","[]","allowlists","List of domains to allow. You can use regular expressions. This allow list only applies to blocklist matches on items in this policy"
+    "domains_block","list of strings","false","[]","blocklists","List of domains to blocklist. Only exact matches are supported"
+    "wildcard_domains_block","list of strings","false","[]","wildcards_block,wildcard_domains,wildcards","List of wildcard domains to blocklist. All subdomains of the given domain will be blocked. Blocking first-level domains is not supported"
+    "source_networks","list of strings","false","[]","networks,source_nets,src_nets","Source networks to apply policy on. Examples are 192.168.1.0/24 or 192.168.1.1. Leave empty to apply on everything. All specified networks should use the same protocol family and have equal sizes to avoid priority issue"
+    "cache_ttl","int","false","72000","ttl","TTL-seconds for the blocklists cache. Remote blocklists don't usually update more often than once a day. Therefore, when blocklists are downloaded, they are cached locally to prevent unnecessary fetches over the internet. You can change this behavior here if you know the remote files rotate faster than this"
+    "nxdomain_address","string","false","\-","address,redirect_to","Destination ip address for entries in the blocklist (leave empty to use default: 0.0.0.0). Not used when "Return NXDOMAIN" is checked"
     "nxdomain","bool","false","false","\-","Use the DNS response code NXDOMAIN instead of a destination address"
-    "enabled","boolean","false","true","\-","Enable the usage of DNS blocklists"
-    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
 
 .. include:: ../_include/param_basic.rst
-
-----
-
-Usage
-*****
-
-Manage Unbound DNS blocklists and exceptions.
 
 ----
 
@@ -75,22 +71,30 @@ Examples
         # add their default values to get a brief overview of how the module works
         - name: Example
           oxlorg.opnsense.unbound_dnsbl:
-            type: atl
-            # safesearch: false
-            # lists: ['https://example.com/dns.blocklist']
-            # whitelists: ['opnsense.oxl.app']
-            # blocklists: ['example.net']
-            # wildcards: ['example.net']
-            # address: 192.168.254.254
+            name: 'example DNS-BL'
+            providers: ['atf']
+            # download_urls: ['https://example.com/dns.blocklist']
+            # domains_allow: ['opnsense.org', 'oxl.at']
+            # domains_block: ['example.porn.org']
+            # wildcard_domains_block: ['evil.org']
+            # source_networks: ['10.0.10.0/24', '10.2.10.0/24']
+            # nxdomain_address: '192.168.255.255'
             # nxdomain: false
             # enabled: false
             # state: 'absent'
             # debug: false
 
-        - name: Configuring DNS Blocklists
+        - name: Adding DNS Blocklists
           oxlorg.opnsense.unbound_dnsbl:
-            type: atl
-            enabled: true
+            name: 'Provider DNS-BLs'
+            providers: ['atf', 'atl']
+            domains_allow: ['site-to-exclude.com']
+
+        - name: Blocking some social media for client-networks
+          oxlorg.opnsense.unbound_dnsbl:
+            name: 'Social Media'
+            wildcard_domains_block: ['facebook.com', 'meta.com', 'tiktok.com']
+            source_networks: ['192.168.0.0/16']
 
         - name: Listing current config
           oxlorg.opnsense.list:
@@ -100,4 +104,3 @@ Examples
         - name: Printing
           ansible.builtin.debug:
             var: dnsbl_config.data
-

--- a/plugins/module_utils/main/unbound_dnsbl.py
+++ b/plugins/module_utils/main/unbound_dnsbl.py
@@ -2,29 +2,47 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import \
     Session
-from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.cls import GeneralModule
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.cls import BaseModule
 
 
-# Supported as of OPNsense 23.7
-class DnsBL(GeneralModule):
+class DnsBL(BaseModule):
+    FIELD_ID = 'name'
     CMDS = {
-        'set': 'set',
-        'search': 'get',
+        'add': 'addDnsbl',
+        'set': 'setDnsbl',
+        'del': 'delDnsbl',
+        'search': 'searchDnsbl',
+        'detail': 'getDnsbl',
     }
-    API_KEY_PATH = 'unbound.dnsbl'
-    API_KEY_PATH_REQ = API_KEY_PATH
+    API_KEY_PATH = 'blocklist'
     API_MOD = 'unbound'
     API_CONT = 'settings'
     API_CONT_REL = 'service'
-    API_CMD_REL = 'reconfigureGeneral'
+    API_CMD_REL = 'dnsbl'
     FIELDS_CHANGE = [
-        'enabled', 'safesearch', 'type', 'lists', 'whitelists', 'blocklists', 'wildcards', 'address', 'nxdomain'
+        'enabled', 'providers', 'download_urls', 'domains_allow', 'domains_block', 'wildcard_domains_block',
+        'source_networks', 'cache_ttl', 'nxdomain_address', 'nxdomain',
     ]
-    FIELDS_ALL = FIELDS_CHANGE
-    FIELDS_TYPING = {
-        'bool': ['enabled', 'safesearch', 'nxdomain'],
-        'list': ['type', 'lists', 'whitelists', 'blocklists', 'wildcards'],
+    FIELDS_ALL = [FIELD_ID]
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'name': 'description',
+        'providers': 'type',
+        'download_urls': 'lists',
+        'nxdomain_address': 'address',
+        'domains_allow': 'allowlists',
+        'domains_block': 'blocklists',
+        'wildcard_domains_block': 'wildcards',
+        'source_networks': 'source_nets',
     }
+    FIELDS_TYPING = {
+        'bool': ['enabled', 'nxdomain'],
+        'int': ['cache_ttl'],
+        'list': ['providers', 'download_urls', 'domains_allow', 'domains_block', 'wildcard_domains_block', 'source_networks'],
+    }
+    EXIST_ATTR = 'bl'
+    TIMEOUT = 60.0  # 'reload' timeout
 
     def __init__(self, module: AnsibleModule, result: dict, session: Session = None):
-        GeneralModule.__init__(self=self, m=module, r=result, s=session)
+        BaseModule.__init__(self=self, m=module, r=result, s=session)
+        self.bl = {}

--- a/plugins/module_utils/main/unbound_dnsbl.py
+++ b/plugins/module_utils/main/unbound_dnsbl.py
@@ -38,7 +38,10 @@ class DnsBL(BaseModule):
     FIELDS_TYPING = {
         'bool': ['enabled', 'nxdomain'],
         'int': ['cache_ttl'],
-        'list': ['providers', 'download_urls', 'domains_allow', 'domains_block', 'wildcard_domains_block', 'source_networks'],
+        'list': [
+            'providers', 'download_urls', 'domains_allow', 'domains_block',
+            'wildcard_domains_block', 'source_networks',
+        ],
     }
     EXIST_ATTR = 'bl'
     TIMEOUT = 60.0  # 'reload' timeout

--- a/plugins/modules/unbound_dnsbl.py
+++ b/plugins/modules/unbound_dnsbl.py
@@ -14,7 +14,7 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
-        OPN_MOD_ARGS, EN_ONLY_MOD_ARG, RELOAD_MOD_ARG
+        OPN_MOD_ARGS, STATE_MOD_ARG, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.unbound_dnsbl import DnsBL
 
 except MODULE_EXCEPTIONS:
@@ -27,33 +27,53 @@ except MODULE_EXCEPTIONS:
 
 def run_module():
     module_args = dict(
-        safesearch=dict(
-            type='bool', required=False, default=False,
-            description='Force the usage of SafeSearch on Google, DuckDuckGo, Bing, Qwant, PixaBay and YouTube'
+        name=dict(
+            type='str', required=True, aliases=['description', 'desc'],
+            description='Unique name to identify the entry',
         ),
-        type=dict(
-            type='list', elements='str', required=False, default=[], aliases=['bl'],
-            description='Select which kind of DNSBL you want to use'
+        providers=dict(
+            type='list', elements='str', required=False, default=[],
+            aliases=['type', 'dnsbl', 'bl'],
+            description='Select which kind of DNSBL you want to use.'
         ),
-        lists=dict(
-            type='list', elements='str', required=False, default=[], aliases=['list'],
-            description='List of urls from where blocklist will be downloaded'
+        download_urls=dict(
+            type='list', elements='str', required=False, default=[],
+            aliases=['download', 'lists'],
+            description='List of URLs/domains from where blocklist will be downloaded'
         ),
-        whitelists=dict(
-            type='list', elements='str', required=False, default=[], aliases=['whitelist', 'allowlist', 'allowlists'],
-            description='List of domains to whitelist. You can use regular expressions'
+        domains_allow=dict(
+            type='list', elements='str', required=False, default=[], aliases=['allowlists'],
+            description='List of domains to allow. You can use regular expressions. '
+                        'This allow list only applies to blocklist matches on items in this policy'
         ),
-        blocklists=dict(
-            type='list', elements='str', required=False, default=[], aliases=['blocklist'],
+        domains_block=dict(
+            type='list', elements='str', required=False, default=[], aliases=['blocklists'],
             description='List of domains to blocklist. Only exact matches are supported'
         ),
-        wildcards=dict(
-            type='list', elements='str', required=False, default=[], aliases=['wildcard'],
+        wildcard_domains_block=dict(
+            type='list', elements='str', required=False, default=[],
+            aliases=['wildcards_block', 'wildcard_domains', 'wildcards'],
             description='List of wildcard domains to blocklist. All subdomains of the given domain will be blocked. '
                         'Blocking first-level domains is not supported'
         ),
-        address=dict(
-            type='str', required=False,
+        source_networks=dict(
+            type='list', elements='str', required=False, default=[],
+            aliases=['networks', 'source_nets', 'src_nets'],
+            description='Source networks to apply policy on. '
+                        'Examples are 192.168.1.0/24 or 192.168.1.1. Leave empty to apply on everything. '
+                        'All specified networks should use the same protocol family and '
+                        'have equal sizes to avoid priority issue'
+        ),
+        cache_ttl=dict(
+            type='int', required=False, default=72_000, aliases=['ttl'],
+            description="TTL-seconds for the blocklists cache. "
+                        "Remote blocklists don't usually update more often than once a day. "
+                        "Therefore, when blocklists are downloaded, they are cached locally to prevent "
+                        "unnecessary fetches over the internet. You can change this behavior here if you know "
+                        "the remote files rotate faster than this"
+        ),
+        nxdomain_address=dict(
+            type='str', required=False, aliases=['address', 'redirect_to'],
             description='Destination ip address for entries in the blocklist (leave empty to use default: 0.0.0.0). '
                         'Not used when "Return NXDOMAIN" is checked'
         ),
@@ -61,7 +81,7 @@ def run_module():
             type='bool', required=False, default=False,
             description='Use the DNS response code NXDOMAIN instead of a destination address'
         ),
-        **EN_ONLY_MOD_ARG,
+        **STATE_MOD_ARG,
         **OPN_MOD_ARGS,
         **RELOAD_MOD_ARG,
     )

--- a/tests/1_cleanup.yml
+++ b/tests/1_cleanup.yml
@@ -123,6 +123,14 @@
         - 'ANSIBLE_TEST_1_3'
         - 'ANSIBLE_TEST_2_1'
 
+    - name: Cleanup
+      oxlorg.opnsense.unbound_dnsbl:
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1'
+        - 'ANSIBLE_TEST_2'
+
     - name: Cleanup syslog
       oxlorg.opnsense.syslog:
         description: "{{ item }}"

--- a/tests/unbound_dnsbl.yml
+++ b/tests/unbound_dnsbl.yml
@@ -21,76 +21,86 @@
       register: opn_pre1
       failed_when: >
         opn_pre1.failed or
-        'data' not in opn_pre1
+        opn_pre1.data | length != 0
 
     - name: Configuring - failing because of invalid type
       oxlorg.opnsense.unbound_dnsbl:
-        type:
-          - ANSIBLE_TEST_1
+        name: 'ANSIBLE_TEST_1'
+        providers:
+          - 'INVALID'
       register: opn_fail1
       failed_when: not opn_fail1.failed
       when: not ansible_check_mode
 
     - name: Configuring - failing because of invalid address
       oxlorg.opnsense.unbound_dnsbl:
-        address: INVALID
+        name: 'ANSIBLE_TEST_1'
+        address: 'INVALID'
       register: opn_fail2
       failed_when: not opn_fail2.failed
       when: not ansible_check_mode
 
-    - name: Reset Configuring
+    - name: Adding 1
       oxlorg.opnsense.unbound_dnsbl:
-      when: not ansible_check_mode
-
-    - name: Configuring
-      oxlorg.opnsense.unbound_dnsbl:
-        type:
-          - atf
-        lists: ['https://example.com/dns.blocklist']
-        whitelists:
-          - opnsense.org
-          - oxlorg.net
-        blocklists:
-          - example.tor
-        wildcards:
-          - example.tor
-        address: 192.168.255.255
+        name: 'ANSIBLE_TEST_1'
+        providers: 'atf'
+        download_urls: ['https://example.com/dns.blocklist']
+        domains_allow:
+          - 'opnsense.org'
+          - 'oxlorg.net'
+        domains_block:
+          - 'example.tor'
+        wildcard_domains_block:
+          - 'example.tor'
+        source_networks:
+          - '10.0.10.0/24'
+          - '10.2.10.0/24'
+        nxdomain_address: '192.168.255.255'
         nxdomain: false
         enabled: true
+        reload: false  # speed
       register: opn1
       failed_when: >
         opn1.failed or
         not opn1.changed
 
-    - name: Changing
+    - name: Changing 1
       oxlorg.opnsense.unbound_dnsbl:
-        type:
-          - atf
-        whitelists:
-          - opnsense.org
-          - oxlorg.net
-        blocklists:
-          - example.tor
-        wildcards:
-          - example.tor
+        name: 'ANSIBLE_TEST_1'
+        providers: 'atf'
+        domains_allow:
+          - 'opnsense.org'
+          - 'oxl.at'
+        domains_block:
+          - 'example.tor'
+        wildcard_domains_block:
+          - 'example.tor'
+        source_networks:
+          - '10.10.10.0/24'
+          - '10.3.10.0/24'
         nxdomain: true
         enabled: true
+        reload: false  # speed
       register: opn2
       failed_when: >
         opn2.failed or
         not opn2.changed
+      when: not ansible_check_mode
 
     - name: Disabling 1
       oxlorg.opnsense.unbound_dnsbl:
-        type:
-          - atf
-        whitelists:
-          - opnsense.org
-          - oxlorg.net
-        blocklists:
-          - example.tor
-        wildcards:
-          - example.tor
+        name: 'ANSIBLE_TEST_1'
+        providers: 'atf'
+        domains_allow:
+          - 'opnsense.org'
+          - 'oxl.at'
+        domains_block:
+          - 'example.tor'
+        wildcard_domains_block:
+          - 'example.tor'
+        source_networks:
+          - '10.10.10.0/24'
+          - '10.3.10.0/24'
         nxdomain: true
         enabled: false
         reload: false  # speed
@@ -102,15 +112,18 @@
 
     - name: Nothing changed
       oxlorg.opnsense.unbound_dnsbl:
-        type:
-          - atf
-        whitelists:
-          - opnsense.org
-          - oxlorg.net
-        blocklists:
-          - example.tor
-        wildcards:
-          - example.tor
+        name: 'ANSIBLE_TEST_1'
+        providers: 'atf'
+        domains_allow:
+          - 'opnsense.org'
+          - 'oxl.at'
+        domains_block:
+          - 'example.tor'
+        wildcard_domains_block:
+          - 'example.tor'
+        source_networks:
+          - '10.10.10.0/24'
+          - '10.3.10.0/24'
         nxdomain: true
         enabled: false
         reload: false  # speed
@@ -120,7 +133,47 @@
         opn4.changed
       when: not ansible_check_mode
 
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn6
+      failed_when: >
+        opn6.failed or
+        opn6.data | length != 1
+      when: not ansible_check_mode
+
+    - name: Adding 2
+      oxlorg.opnsense.unbound_dnsbl:
+        name: 'ANSIBLE_TEST_2'
+        providers: 'atf'
+        download_urls: ['https://example.com/dns.blocklist']
+        domains_block:
+          - 'example.tor'
+        source_networks:
+          - '10.0.10.0/24'
+          - '10.2.10.0/24'
+        nxdomain: false
+        cache_ttl: 1000000
+        enabled: true
+        reload: false  # speed
+      register: opn5
+      failed_when: >
+        opn5.failed or
+        not opn5.changed
+      when: not ansible_check_mode
+
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn7
+      failed_when: >
+        opn7.failed or
+        opn7.data | length != 2
+      when: not ansible_check_mode
+
     - name: Cleanup
       oxlorg.opnsense.unbound_dnsbl:
-        reload: false
+        name: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1'
+        - 'ANSIBLE_TEST_2'
       when: not ansible_check_mode


### PR DESCRIPTION
We now can manage multiple blocklists :partying_face: 