### PR TITLE
fix(haproxy_action): consolidate http-request action types for HAProxy 5

### DIFF
--- a/plugins/modules/haproxy_action.py
+++ b/plugins/modules/haproxy_action.py
@@ -53,11 +53,7 @@ def run_module():
         type=dict(
             type='str', required=False, default=None,
             choices=['use_backend', 'use_server', 'map_use_backend', 'fcgi_pass_header', 'fcgi_set_param',
-                     'http-request_allow', 'http-request_deny', 'http-request_tarpit', 'http-request_auth',
-                     'http-request_redirect', 'http-request_lua', 'http-request_use-service',
-                     'http-request_add-header', 'http-request_set-header', 'http-request_del-header',
-                     'http-request_replace-header', 'http-request_replace-value', 'http-request_set-path',
-                     'http-request_set-var', 'http-response_allow', 'http-response_deny', 'http-response_lua',
+                     'http-request', 'http-response_allow', 'http-response_deny', 'http-response_lua',
                      'http-response_add-header', 'http-response_set-header', 'http-response_del-header',
                      'http-response_replace-header', 'http-response_replace-value', 'http-response_set-status',
                      'http-response_set-var', 'monitor_fail', 'tcp-request_connection_accept',


### PR DESCRIPTION
Replace individual http-request_* choices (allow, deny, tarpit, auth, redirect, lua, use-service, add-header, set-header, del-header, replace-header, replace-value, set-path, set-var) with a single generic 'http-request' type to support HAProxy 5.0.

I haven't tested all actions but the existing `http-request_*` I use fail after the latest opnsense upgrade.