### PR TITLE
Skip missing fields during typing

### DIFF
--- a/plugins/module_utils/helper/main.py
+++ b/plugins/module_utils/helper/main.py
@@ -336,6 +336,9 @@ def simplify_translate(
                 if f in ignore:
                     continue
 
+                if f not in simple:
+                    continue
+                    
                 if t == 'bool':
                     simple[f] = is_true(simple[f])
 


### PR DESCRIPTION
Implements @lukaszkaczorowski's workaround for #366. Was encountering the same error, and it does indeed unblock the module.