### PR TITLE
Bug fix: In Dnsmasq, add `resolv_system` to `FIELDS_BOOL_INVERT`

### DIFF
--- a/plugins/module_utils/main/dnsmasq_general.py
+++ b/plugins/module_utils/main/dnsmasq_general.py
@@ -41,7 +41,7 @@ class General(GeneralModule):
         'dhcp_enable_ra': ('dhcp', 'enable_ra'),
         'dhcp_hasync': ('dhcp', 'nosync'),
     }
-    FIELDS_BOOL_INVERT = ['resolve_etc_hosts', 'ident', 'forward_private_reverse', 'dhcp_hasync']
+    FIELDS_BOOL_INVERT = ['resolve_etc_hosts', 'ident', 'forward_private_reverse', 'dhcp_hasync', 'resolv_system']
     FIELDS_TYPING = {
         'bool': [
             'enabled','regdhcp','regdhcpstatic','domain_needed', 'dnssec', 'resolve_etc_hosts', 'dhcpfirst',


### PR DESCRIPTION
## Summary

This PR adds `resolv_system` to `FIELDS_BOOL_INVERT`.

Fixes #420

## Background

The `resolv_system` parameter was added in #307.

According to `FIELDS_TRANSLATE`, `resolv_system` translates to `no_resolv`.

The definitions of those parameters are:
- According to the [OPNsense source code](https://github.com/opnsense/core/blob/c35c8de07e1cadd9a8cf54d79634ef07cb0c797f/src/opnsense/mvc/app/controllers/OPNsense/Dnsmasq/forms/general.xml#L101-L106), the OPNsense `dnsmasq.no_resolv` parameter means: "Do not forward to system defined DNS servers"
- According to the [docs for this Ansible Collection](https://ansible-opnsense.oxl.app/modules/dnsmasq.html#oxlorg-opnsense-dnsmasq-general), the Ansible `resolv_system` parameter means: "Forward DNS queries to system nameservers"

Therefore, if I understand correctly, the OPNsense parameter (`no_resolv`) and the Ansible parameter (`resolv_system`) have the opposite meaning. However, #307 did not add `resolv_system` to `FIELDS_BOOL_INVERT`.

---

Disclosure: I used generative AI to assist in debugging. However, I wrote the source code change myself, and I wrote the text of this PR (and the text of the issue #420) myself.