### PR TITLE
Add nat_destination module (Destination NAT / port-forward)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ venv/
 .coverage.*
 __pycache__
 /test.log
-/test.sh.DS_Store
+/test.sh
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ venv/
 .coverage.*
 __pycache__
 /test.log
-/test.sh
+/test.sh.DS_Store

--- a/docs/meta/sitemap.xml
+++ b/docs/meta/sitemap.xml
@@ -36,6 +36,7 @@
    <url><loc>https://ansible-opnsense.oxl.app/modules/interface.html</loc></url>
    <url><loc>https://ansible-opnsense.oxl.app/modules/ipsec.html</loc></url>
    <url><loc>https://ansible-opnsense.oxl.app/modules/monit.html</loc></url>
+   <url><loc>https://ansible-opnsense.oxl.app/modules/nat_destination.html</loc></url>
    <url><loc>https://ansible-opnsense.oxl.app/modules/neighbor.html</loc></url>
    <url><loc>https://ansible-opnsense.oxl.app/modules/nginx.html</loc></url>
    <url><loc>https://ansible-opnsense.oxl.app/modules/openvpn.html</loc></url>

--- a/docs/source/modules/nat_destination.rst
+++ b/docs/source/modules/nat_destination.rst
@@ -1,0 +1,166 @@
+.. _modules_nat_destination:
+
+.. include:: ../_include/head.rst
+
+===============
+NAT Destination
+===============
+
+**STATE**: unstable
+
+**TESTS**: `Playbook <https://github.com/O-X-L/ansible-opnsense/blob/latest/tests/nat_destination.yml>`_
+
+**API Docs**: `Core - Firewall <https://docs.opnsense.org/development/api/core/firewall.html>`_
+
+**Service Docs**: `Port Forward (Destination NAT) <https://docs.opnsense.org/manual/nat.html#port-forwards>`_
+
+----
+
+Info
+****
+
+Savepoint
+=========
+
+You can prevent lockout-situations using the savepoint systems:
+
+- :ref:`oxlorg.opnsense.savepoint <modules_savepoint>`
+
+Web-UI
+======
+
+These rules are shown in the separate WEB-UI table.
+
+Menu: 'Firewall - NAT - Port Forward'
+
+Definition
+**********
+
+Module alias: oxlorg.opnsense.dnat
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "match_fields","list","true","\-","\-","Fields that are used to match configured rules with the running config - if any of those fields are changed, the module will think it's a new rule. At least one of: 'sequence', 'interface', 'ip_protocol', 'protocol', 'source_invert', 'source_net', 'source_port', 'destination_invert', 'destination_net', 'destination_port', 'target', 'local_port', 'description', 'uuid', 'no_port_forward'"
+    "sequence","int","false","1","seq","Sequence for rule processing, Integer between 1 and 999999"
+    "interface","list","false for deletion, else true","['lan']","int, i","One or multiple interfaces to match this rule on"
+    "ip_protocol","string","false","'inet'","ip, ip_proto","IP protocol to match. One of: 'inet', 'inet6', 'inet46' (*IPv4 = 'inet', IPv6 = 'inet6', Both = 'inet46'*)"
+    "protocol","string","false","'any'","proto, p","Protocol like 'TCP', 'UDP', 'ICMP', 'TCP/UDP' and so on. For options see the WEB-UI."
+    "source_invert","boolean","false","false","src_inv, si, src_not","Inverted matching of the source"
+    "source_net","string","false","'any'","source, src, s","Host, network, alias or 'any'"
+    "source_port","string","false","\-","src_port, sp","Leave empty to allow all, valid port-number, name, alias or range"
+    "destination_invert","boolean","false","false","dest_inv, di, dest_not","Inverted matching of the destination"
+    "destination_net","string","false","'any'","destination, dest, d","Host, network, alias or 'any'"
+    "destination_port","string","false","\-","dest_port, dp","Leave empty to allow all, valid port-number, name, alias or range"
+    "target","string","false for deletion, else true","\-","tgt, t","NAT translation target - IP-Address or alias the matching traffic will be redirected to. Grouped aliases (with multiple entries) can be used for load-balancing."
+    "local_port","string","false","\-","nat_port, np","Port the packet will be redirected to - port-number, well-known name or alias"
+    "pool_opts","string","false","''","pool_options","Only used if 'target' resolves to multiple entries (load-balancing pool). One of: '', 'round-robin', 'round-robin sticky-address', 'random', 'random sticky-address', 'source-hash', 'bitmask'. Empty uses the system default."
+    "nat_reflection","string","false","''","\-","One of: '', 'purenat', 'disable'. Empty uses the system default."
+    "associated_rule","string","false","''","pass","Whether and how a matching firewall-rule should be created for this port-forward. One of: '' (*manual - you have to create the matching filter-rule yourself*), 'pass' (*automatically allow the redirected traffic*), 'rule' (*register an associated but separately editable filter-rule*)"
+    "no_port_forward","boolean","false","false","nordr","Packets matching this rule will be passed without a port-forward being applied - useful to define exceptions on top of a more general rule"
+    "log","boolean","false","true","l","If rule matches should be shown in the firewall logs"
+    "description","string","false","\-","name, desc","Description for the rule"
+    "tag","string","false","\-","\-","Set a tag on matching packets - can be used with 'tagged' on other rules to build rule-chains"
+    "tagged","string","false","\-","\-","Match packets that were tagged with the given value"
+    "state","string","false","'present'","st","State of the rule. One of: 'present', 'absent'"
+    "enabled","boolean","false","true","en","If the rule should be en- or disabled"
+    "uuid","string","false","\-","\-","Optionally you can supply the uuid of an existing rule"
+    "reload","boolean","false","true","apply", .. include:: ../_include/param_reload.rst
+
+.. include:: ../_include/param_basic.rst
+
+----
+
+Usage
+*****
+
+First you will have to know about **rule-matching**.
+
+The module somehow needs to link the configured and existing rules to manage them.
+
+You need to set how this matching is done by setting the 'match_fields' parameter!
+
+It is **recommended** to use/set **unique identifiers** like 'description' to make sure rules can be matched without overlapping.
+
+You could also use the UUID of existing rules as ID - but you would have to pull (*list*) and configure those 'manually'.
+
+Note that this module only manages the port-forward (destination-NAT) rule itself. If you don't set 'associated_rule' to
+automatically pass the traffic - you will also need a matching :ref:`oxlorg.opnsense.rule <modules_rule>` to allow it through the filter.
+
+----
+
+Examples
+********
+
+.. code-block:: yaml
+
+    - hosts: firewalls
+      connection: local
+      gather_facts: false
+      module_defaults:
+        group/oxlorg.opnsense.all:
+          firewall: 'opnsense.template.opnsense.oxl.app'
+          api_credential_file: '/home/guy/.secret/opn.key'
+
+        oxlorg.opnsense.nat_destination:
+          match_fields: ['description']
+
+        oxlorg.opnsense.list:
+          target: 'nat_destination'
+
+      tasks:
+        - name: Example
+          oxlorg.opnsense.nat_destination:
+            description: 'example'
+            match_fields: ['description']
+            interface: ['wan']
+            destination_net: '1.2.3.4'
+            destination_port: '443'
+            target: '192.168.0.10'
+            local_port: '8443'
+            # sequence: 1
+            # ip_protocol: 'inet'
+            # protocol: 'TCP'
+            # source_invert: false
+            # source_net: 'any'
+            # source_port: 'any'
+            # pool_opts: ''
+            # nat_reflection: ''
+            # associated_rule: 'pass'
+            # no_port_forward: false
+            # log: true
+            # enabled: true
+            # debug: false
+            # state: 'present'
+            # reload: true
+
+        - name: Adding a port-forward
+          oxlorg.opnsense.nat_destination:
+            description: 'web-server'
+            interface: ['wan']
+            protocol: 'TCP'
+            destination_net: 'wanip'
+            destination_port: '443'
+            target: '192.168.0.10'
+            local_port: '8443'
+            associated_rule: 'pass'
+
+        - name: Disabling the rule
+          oxlorg.opnsense.nat_destination:
+            description: 'web-server'
+            enabled: false
+
+        - name: Listing
+          oxlorg.opnsense.list:
+          #  target: 'nat_destination'
+          register: existing_entries
+
+        - name: Printing
+          ansible.builtin.debug:
+            var: existing_entries.data
+
+        - name: Removing the rule
+          oxlorg.opnsense.nat_destination:
+            description: 'web-server'
+            state: 'absent'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -109,6 +109,7 @@ action_groups:
   nat:
     - oxlorg.opnsense.nat_source
     - oxlorg.opnsense.nat_one_to_one
+    - oxlorg.opnsense.nat_destination
   system:
     - oxlorg.opnsense.list
     - oxlorg.opnsense.reload
@@ -248,6 +249,8 @@ plugin_routing:
       redirect: oxlorg.opnsense.ipsec_pool
     snat:
       redirect: oxlorg.opnsense.source_nat
+    dnat:
+      redirect: oxlorg.opnsense.destination_nat
     proxy_general:
       redirect: oxlorg.opnsense.webproxy_general
     proxy_cache:
@@ -294,5 +297,7 @@ plugin_routing:
       redirect: oxlorg.opnsense.nat_source
     one_to_one:
       redirect: oxlorg.opnsense.nat_one_to_one
+    destination_nat:
+      redirect: oxlorg.opnsense.nat_destination
     wireguard_client:
       redirect: oxlorg.opnsense.wireguard_peer

--- a/plugins/module_utils/main/nat_destination.py
+++ b/plugins/module_utils/main/nat_destination.py
@@ -1,0 +1,77 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.module import BaseModule
+
+
+class DNat(BaseModule):
+    CMDS = {
+        'add': 'add_rule',
+        'del': 'del_rule',
+        'set': 'set_rule',
+        'search': 'get',
+        'toggle': 'toggle_rule',
+    }
+    API_KEY_PATH = 'DNat.rule'
+    API_MOD = 'firewall'
+    API_CONT = 'd_nat'
+    FIELDS_CHANGE = [
+        'sequence', 'no_port_forward', 'interface', 'ip_protocol', 'protocol',
+        'source_invert', 'source_net', 'source_port',
+        'destination_invert', 'destination_net', 'destination_port',
+        'target', 'local_port', 'pool_opts', 'log', 'description', 'tag', 'tagged',
+        'nat_reflection', 'associated_rule',
+    ]
+    FIELDS_ALL = ['enabled']
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_BOOL_INVERT = ['enabled']
+    FIELDS_TRANSLATE = {
+        'enabled': 'disabled',
+        'no_port_forward': 'nordr',
+        'ip_protocol': 'ipprotocol',
+        'source_invert': ('source', 'not'),
+        'source_net': ('source', 'network'),
+        'source_port': ('source', 'port'),
+        'destination_invert': ('destination', 'not'),
+        'destination_net': ('destination', 'network'),
+        'destination_port': ('destination', 'port'),
+        'local_port': 'local-port',
+        'pool_opts': 'poolopts',
+        'description': 'descr',
+        'nat_reflection': 'natreflection',
+        'associated_rule': 'pass',
+    }
+    FIELDS_TYPING = {
+        'bool': ['enabled', 'log', 'no_port_forward', 'source_invert', 'destination_invert'],
+        'list': ['interface'],
+        'select': ['ip_protocol', 'protocol', 'pool_opts', 'nat_reflection', 'associated_rule'],
+        'int': ['sequence'],
+    }
+    INT_VALIDATIONS = {
+        'sequence': {'min': 1, 'max': 999999},
+    }
+    EXIST_ATTR = 'rule'
+    API_CMD_REL = 'apply'
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None, fail: dict = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session, f=fail)
+        self.rule = {}
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            if is_unset(self.p['target']):
+                self.m.fail_json(
+                    "You need to provide a 'target' to create a destination-nat rule!"
+                )
+
+        if not is_unset(self.p['protocol']):
+            # OPNsense stores/returns 'protocol' lowercase (model enforces 'ChangeCase: lower') -
+            # normalize here so diff-comparisons against the existing entry don't falsely report a change
+            self.p['protocol'] = self.p['protocol'].lower()
+
+        self.find(match_fields=self.p['match_fields'])
+
+        self._base_check()

--- a/plugins/modules/list.py
+++ b/plugins/modules/list.py
@@ -41,6 +41,7 @@ TARGETS = [
     'acme_validation', 'acme_action', 'acme_certificate', 'postfix_general', 'postfix_domain', 'postfix_recipient',
     'postfix_recipientbcc', 'postfix_sender', 'postfix_senderbcc', 'postfix_sendercanonical', 'postfix_headercheck',
     'postfix_address', 'dhcp_subnet', 'dhcp_general', 'interface_gre', 'nat_one_to_one', 'nat_source',
+    'nat_destination',
     'ipsec_manual_spd', 'hasync_general', 'snapshot', 'frr_bgp_redistribution', 'frr_ospf_redistribution',
     'frr_ospf3_redistribution', 'frr_ospf3_route_map', 'frr_ospf3_prefix_list', 'frr_ospf3_network',
     'frr_bgp_peer_group', 'user', 'group', 'privilege', 'interface_bridge', 'interface_gif', 'neighbor',
@@ -216,6 +217,10 @@ def run_module():
         elif target == 'nat_one_to_one':
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_one_to_one import \
                 OneToOne as Target_Obj
+
+        elif target == 'nat_destination':
+            from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_destination import \
+                DNat as Target_Obj
 
         elif target == 'frr_general':
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.frr_general \

--- a/plugins/modules/nat_destination.py
+++ b/plugins/modules/nat_destination.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# see: https://docs.opnsense.org/development/api/core/firewall.html
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.rule import \
+        RULE_MOD_ARGS
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, STATE_MOD_ARG, RELOAD_MOD_ARG
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_destination import DNat
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://ansible-opnsense.oxl.app/modules/nat_destination.html'
+# EXAMPLES = 'https://ansible-opnsense.oxl.app/modules/nat_destination.html'
+
+
+def run_module():
+    shared_rule_args = {
+        'sequence': RULE_MOD_ARGS['sequence'],
+        'interface': RULE_MOD_ARGS['interface'],
+        'ip_protocol': RULE_MOD_ARGS['ip_protocol'],
+        'protocol': RULE_MOD_ARGS['protocol'],
+        'source_invert': RULE_MOD_ARGS['source_invert'],
+        'source_net': RULE_MOD_ARGS['source_net'],
+        'source_port': RULE_MOD_ARGS['source_port'],
+        'destination_invert': RULE_MOD_ARGS['destination_invert'],
+        'destination_net': RULE_MOD_ARGS['destination_net'],
+        'destination_port': RULE_MOD_ARGS['destination_port'],
+        'log': RULE_MOD_ARGS['log'],
+        'uuid': RULE_MOD_ARGS['uuid'],
+        'description': RULE_MOD_ARGS['description'],
+        'tag': RULE_MOD_ARGS['tag'],
+        'tagged': RULE_MOD_ARGS['tagged'],
+    }
+
+    module_args = dict(
+        no_port_forward=dict(
+            type='bool', required=False, default=False, aliases=['nordr'],
+            description='Packets matching this rule will be passed without a port-forward '
+                        'being applied - useful to define exceptions on top of a more general rule.'
+        ),
+        target=dict(
+            type='str', required=False, aliases=['tgt', 't'],
+            description='NAT translation target - IP-Address or alias the matching traffic will be '
+                        'redirected to. Grouped aliases (with multiple entries) can be used for load-balancing.'
+        ),
+        local_port=dict(
+            type='str', required=False, aliases=['nat_port', 'np'],
+            description='Port the packet will be redirected to - port-number, well-known name or alias'
+        ),
+        pool_opts=dict(
+            type='str', required=False, default='', aliases=['pool_options'],
+            choices=[
+                '', 'round-robin', 'round-robin sticky-address', 'random',
+                'random sticky-address', 'source-hash', 'bitmask',
+            ],
+            description="Only used if 'target' resolves to multiple entries (load-balancing pool). "
+                        "Empty value uses the system default."
+        ),
+        nat_reflection=dict(
+            type='str', required=False, default='', choices=['', 'purenat', 'disable'],
+            description="Empty value uses the system default."
+        ),
+        associated_rule=dict(
+            type='str', required=False, default='', choices=['', 'pass', 'rule'], aliases=['pass'],
+            description="Whether and how a matching firewall-rule should be created for this port-forward. "
+                        "Empty = manual (you have to create the matching filter-rule yourself), "
+                        "'pass' = automatically allow the redirected traffic, "
+                        "'rule' = register an associated but separately editable filter-rule."
+        ),
+        match_fields=dict(
+            type='list', required=True, elements='str',
+            description='Fields that are used to match configured rules with the running config - '
+                        "if any of those fields are changed, the module will think it's a new rule",
+            choices=[
+                'sequence', 'interface', 'ip_protocol', 'protocol', 'source_invert', 'source_net',
+                'source_port', 'destination_invert', 'destination_net', 'destination_port',
+                'target', 'local_port', 'description', 'uuid', 'no_port_forward',
+            ]
+        ),
+        **shared_rule_args,
+        **STATE_MOD_ARG,
+        **RELOAD_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(DNat(module=module, result=result))
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/reload.py
+++ b/plugins/modules/reload.py
@@ -56,6 +56,7 @@ def run_module():
                 'wazuh',
                 'nat_source',
                 'nat_one_to_one',
+                'nat_destination',
                 'nut',
             ],
             description='What part of the running config should be reloaded'
@@ -192,6 +193,10 @@ def run_module():
         elif target == 'nat_one_to_one':
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_one_to_one import \
                 OneToOne as Target_Obj
+
+        elif target == 'nat_destination':
+            from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_destination import \
+                DNat as Target_Obj
 
         elif target == 'nut':
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nut import \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -130,6 +130,7 @@ run_test_soft 'interface_bridge' 1
 run_test_soft 'interface_gif' 1
 run_test_soft 'nat_source' 1
 run_test_soft 'nat_one_to_one' 1
+run_test_soft 'nat_destination' 1
 run_test_soft 'frr_diagnostic' 1
 run_test_soft 'frr_general' 1
 run_test_soft 'frr_bfd_general' 1

--- a/tests/1_cleanup.yml
+++ b/tests/1_cleanup.yml
@@ -304,6 +304,15 @@
         - 'ANSIBLE_TEST_1_1'
         - 'ANSIBLE_TEST_1_2'
 
+    - name: Cleanup destination-nat
+      oxlorg.opnsense.destination_nat:
+        description: "{{ item }}"
+        state: 'absent'
+        match_fields: ['description']
+      loop:
+        - 'ANSIBLE_TEST_1_1'
+        - 'ANSIBLE_TEST_1_2'
+
     - name: Cleanup FRR general settings
       oxlorg.opnsense.frr_general:
         enabled: false

--- a/tests/nat_destination.yml
+++ b/tests/nat_destination.yml
@@ -1,0 +1,194 @@
+---
+
+- name: Testing destination-nat
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/oxlorg.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+
+    oxlorg.opnsense.destination_nat:
+      match_fields: ['description']
+
+    oxlorg.opnsense.list:
+      target: 'nat_destination'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn_pre1
+      failed_when: >
+        'data' not in opn_pre1 or
+        opn_pre1.data | length != 0
+
+    - name: Removing - does not exist
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_1'
+        state: 'absent'
+      register: opn_pre2
+      failed_when: >
+        opn_pre2.failed or
+        opn_pre2.changed
+
+    - name: Adding 1 - failing because no target was provided
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_1'
+        interface: ['lan']
+        destination_net: '192.168.0.1'
+        destination_port: '8080'
+      register: opn_fail1
+      failed_when: not opn_fail1.failed
+
+    - name: Adding 1
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_1'
+        interface: ['lan']
+        protocol: 'TCP'
+        destination_net: '192.168.0.1'
+        destination_port: '8080'
+        target: '192.168.10.2'
+        local_port: '80'
+      register: opn1
+      failed_when: >
+        opn1.failed or
+        not opn1.changed
+
+    - name: Changing 1
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_1'
+        interface: ['lan']
+        protocol: 'TCP'
+        destination_net: '192.168.0.1'
+        destination_port: '8080'
+        target: '192.168.10.5'
+        local_port: '80'
+      register: opn9
+      failed_when: >
+        opn9.failed or
+        not opn9.changed
+
+    - name: Disabling 1
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_1'
+        interface: ['lan']
+        protocol: 'TCP'
+        destination_net: '192.168.0.1'
+        destination_port: '8080'
+        target: '192.168.10.5'
+        local_port: '80'
+        enabled: false
+      register: opn2
+      failed_when: >
+        opn2.failed or
+        not opn2.changed
+      when: not ansible_check_mode
+
+    - name: Disabling 1 - nothing changed (w/ module alias)
+      oxlorg.opnsense.dnat:
+        description: 'ANSIBLE_TEST_1_1'
+        interface: ['lan']
+        protocol: 'TCP'
+        destination_net: '192.168.0.1'
+        destination_port: '8080'
+        target: '192.168.10.5'
+        local_port: '80'
+        enabled: false
+      register: opn3
+      failed_when: >
+        opn3.failed or
+        opn3.changed
+      when: not ansible_check_mode
+
+    - name: Enabling 1
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_1'
+        interface: ['lan']
+        protocol: 'TCP'
+        destination_net: '192.168.0.1'
+        destination_port: '8080'
+        target: '192.168.10.5'
+        local_port: '80'
+      register: opn4
+      failed_when: >
+        opn4.failed or
+        not opn4.changed
+      when: not ansible_check_mode
+
+    - name: Adding 2 - with source-restriction, no_port_forward and associated_rule
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_2'
+        interface: ['wan']
+        protocol: 'TCP'
+        source_invert: true
+        source_net: 'bogons'
+        destination_net: '192.168.0.1'
+        destination_port: '443'
+        target: '192.168.10.6'
+        local_port: '8443'
+        no_port_forward: false
+        associated_rule: 'pass'
+        nat_reflection: 'disable'
+      register: opn5
+      failed_when: >
+        opn5.failed or
+        not opn5.changed
+
+    - name: Adding 2 - nothing changed
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_2'
+        interface: ['wan']
+        protocol: 'TCP'
+        source_invert: true
+        source_net: 'bogons'
+        destination_net: '192.168.0.1'
+        destination_port: '443'
+        target: '192.168.10.6'
+        local_port: '8443'
+        no_port_forward: false
+        associated_rule: 'pass'
+        nat_reflection: 'disable'
+      register: opn6
+      failed_when: >
+        opn6.failed or
+        opn6.changed
+      when: not ansible_check_mode
+
+    - name: Removing 2
+      oxlorg.opnsense.destination_nat:
+        description: 'ANSIBLE_TEST_1_2'
+        state: 'absent'
+      register: opn7
+      failed_when: >
+        opn7.failed or
+        not opn7.changed
+      when: not ansible_check_mode
+
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn8
+      failed_when: >
+        'data' not in opn8 or
+        opn8.data | length != 1
+      when: not ansible_check_mode
+
+    - name: Cleanup
+      oxlorg.opnsense.destination_nat:
+        description: "{{ item }}"
+        state: 'absent'
+      loop:
+        - 'ANSIBLE_TEST_1_1'
+        - 'ANSIBLE_TEST_1_2'
+      when: not ansible_check_mode
+
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn_clean1
+      failed_when: >
+        'data' not in opn_clean1 or
+        opn_clean1.data | length != 0
+      when: not ansible_check_mode


### PR DESCRIPTION
## Summary
Adds a new module `oxlorg.opnsense.nat_destination` (aliases: `dnat`, `destination_nat`)
to manage Destination NAT / port-forward rules (Firewall > NAT > Port Forward),
following the same pattern as the existing `nat_source` and `nat_one_to_one` modules.

## Changes
- plugins/modules/nat_destination.py + plugins/module_utils/main/nat_destination.py
- Registered in meta/runtime.yml, list.py, reload.py (+ short aliases)
- tests/nat_destination.yml + cleanup entry + scripts/test.sh
- docs/source/modules/nat_destination.rst + sitemap entry

## Testing
Ran the functional test suite (normal + check-mode) against a live OPNsense
firewall - all green.