### PR TITLE
fix: recognise CrowdSec plugin aliases as built-in

### DIFF
--- a/plugins/module_utils/defaults/main.py
+++ b/plugins/module_utils/defaults/main.py
@@ -55,6 +55,7 @@ OPN_MOD_ARGS = dict(
 
 BUILTIN_ALIASES = [
     'bogons', 'bogonsv6', 'sshlockout', 'virusprot', '__wazuh_agent_drop',
+    'crowdsec_blocklists', 'crowdsec6_blocklists',
 ]
 BUILTIN_INTERFACE_ALIASES_REG = '^__.*?_network$'  # auto-added interface aliases
 


### PR DESCRIPTION
The os-crowdsec plugin creates and maintains the `crowdsec_blocklists` and `crowdsec6_blocklists` aliases. Add them to BUILTIN_ALIASES
