### PR TITLE
fix: detect rfc5424 changes on existing syslog destinations

### DIFF
--- a/plugins/module_utils/main/syslog.py
+++ b/plugins/module_utils/main/syslog.py
@@ -23,9 +23,9 @@ class Syslog(BaseModule):
     API_CONT_REL = 'service'
     FIELDS_CHANGE = [
         'target', 'transport', 'facility', 'program', 'level', 'certificate',
-        'port', 'description',
+        'port', 'description', 'rfc5424',
     ]
-    FIELDS_ALL = ['rfc5424', 'enabled']
+    FIELDS_ALL = ['enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)
     FIELDS_TRANSLATE = {
         'target': 'hostname',

--- a/plugins/modules/syslog.py
+++ b/plugins/modules/syslog.py
@@ -54,7 +54,7 @@ def run_module():
             ],
         ),
         certificate=dict(type='str', required=False, aliases=['cert']),
-        rfc5424=dict(type='bool', required=False, default=False),  # not getting current value from response
+        rfc5424=dict(type='bool', required=False, default=False),
         description=dict(type='str', required=False, aliases=['desc']),
         match_fields=dict(
             type='list', required=False, elements='str',

--- a/tests/syslog.yml
+++ b/tests/syslog.yml
@@ -107,6 +107,39 @@
         not opn8.changed
       when: not ansible_check_mode
 
+    - name: Enabling rfc5424 on 1
+      oxlorg.opnsense.syslog:
+        description: 'ANSIBLE_TEST_1'
+        target: '192.168.0.1'
+        rfc5424: true
+      register: opn12
+      failed_when: >
+        opn12.failed or
+        not opn12.changed
+      when: not ansible_check_mode
+
+    - name: Enabling rfc5424 on 1 - nothing changed
+      oxlorg.opnsense.syslog:
+        description: 'ANSIBLE_TEST_1'
+        target: '192.168.0.1'
+        rfc5424: true
+      register: opn13
+      failed_when: >
+        opn13.failed or
+        opn13.changed
+      when: not ansible_check_mode
+
+    - name: Disabling rfc5424 on 1
+      oxlorg.opnsense.syslog:
+        description: 'ANSIBLE_TEST_1'
+        target: '192.168.0.1'
+        rfc5424: false
+      register: opn14
+      failed_when: >
+        opn14.failed or
+        not opn14.changed
+      when: not ansible_check_mode
+
     - name: Listing
       oxlorg.opnsense.list:
       register: opn1


### PR DESCRIPTION
A live test works. I wasn't able to find a change upstream that changed the API behaviour, I'm not sure why we decided to skip it previously.