### PR TITLE
Add statistics option to alias module

### DIFF
--- a/docs/source/modules/alias.rst
+++ b/docs/source/modules/alias.rst
@@ -46,6 +46,7 @@ Definition
     "description","string","false","\-","desc","Description for the alias"
     "content","list","false for state changes, else true","\-","cont, c","Values the alias should hold"
     "type","string","false","'host'","t","Type of value the alias should hold. One of: 'host', 'network', 'port', 'url', 'urltable', 'urljson', 'geoip', 'networkgroup', 'mac', 'dynipv6host', 'internal', 'external'"
+    "statistics","boolean","false","false","\-", "Maintain a set of counters for this alias"
     "updatefreq_days","float","false","7.0 if type=urltable","\-","Needed only for the alias-type 'urltable' or 'urljson'. Interval to update its content. Per example: 0.5 for every 12 hours"
     "interface","string","false","\-","int, if","Needed only for the alias-type 'dynipv6host'. Select the interface for the V6 dynamic IP"
     "path_expression","string","false","\-","pr, jq","Needed only for the alias-type 'urljson'. Simplified expression to select a field inside a container, a dot is used as field separator (e.g. container.fieldname). Expressions using the jq language are also supported."

--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -27,6 +27,9 @@ ALIAS_MOD_ARGS = dict(
         description='Simplified expression to select a field inside a container, a dot is used as field separator. '
                     'Expressions using the jq language are also supported.',
     ),
+    statistics=dict(
+        type='bool', default=False, required=False,
+    ),
     url_auth_type=dict(type='str', required=False, default='', aliases=['auth_type'], choices=[
         '', 'Basic', 'Bearer', 'Header',
     ]),

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -25,7 +25,7 @@ class Alias(BaseModule):
     API_KEY_PATH = 'alias.aliases.alias'
     API_MOD = 'firewall'
     API_CONT = 'alias'
-    FIELDS_CHANGE = ['content', 'description']
+    FIELDS_CHANGE = ['content', 'description', 'statistics']
     FIELDS_ALL = ['name', 'type', 'enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)
     FIELDS_ALL.extend([
@@ -34,13 +34,14 @@ class Alias(BaseModule):
     ])
     FIELDS_DIFF_NO_LOG = ['url_password']
     FIELDS_TRANSLATE = {
+        'statistics': 'counters',
         'updatefreq_days': 'updatefreq',
         'url_auth_type': 'authtype',
         'url_username': 'username',
         'url_password': 'password',
     }
     FIELDS_TYPING = {
-        'bool': ['enabled'],
+        'bool': ['enabled', 'statistics'],
         'select': ['type', 'interface'],
     }
     EXIST_ATTR = 'alias'


### PR DESCRIPTION
## Add alias statistics support

The OPNsense API supports enabling alias statistics through the `counters` field, but the Ansible module did not expose it.

This PR adds a new `statistics` parameter to the alias module
