### PR TITLE
fix: support nat_source on OPNsense 26.7

### DIFF
--- a/plugins/module_utils/base/logic.py
+++ b/plugins/module_utils/base/logic.py
@@ -188,7 +188,11 @@ class BaseLogic:
 
                 # todo: perform async calls for parallel data fetching
                 detail_entry = {}
-                if force_details or not base_match_fields or \
+                if base_entry.get('is_automatic'):
+                    if self.raw is None:
+                        self.raw = base_entry
+
+                elif force_details or not base_match_fields or \
                         all(base_entry[field] == self.p[field] for field in match_fields):
                     detail_entry = self._search_path_handling(
                         self._api_get({

--- a/plugins/module_utils/base/logic_pytest.py
+++ b/plugins/module_utils/base/logic_pytest.py
@@ -1,2 +1,43 @@
-def test_placeholder():
-    from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.logic import BaseLogic
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.logic import BaseLogic
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.test.mock_pytest import \
+    MockAnsibleModule
+
+
+class DummySearchLogic(BaseLogic):
+    CMDS = {
+        'search': 'search_rule',
+        'detail': 'get_rule',
+    }
+    API_KEY_PATH = 'rule'
+    API_MOD = 'firewall'
+    API_CONT = 'source_nat'
+    FIELDS_ALL = []
+    FIELDS_CHANGE = []
+    FIELDS_TYPING = {}
+
+    def check(self) -> None:
+        return
+
+
+def test_search_skips_detail_lookup_for_automatic_entries(mocker):
+    module = MockAnsibleModule()
+    module.params.update({
+        'description': 'automatic_isakmp_wan',
+    })
+    result = {'changed': False, 'diff': {'before': {}, 'after': {}}}
+    logic = DummySearchLogic(module, result)
+
+    automatic_entry = {
+        'uuid': 'auto-rule-1',
+        'description': 'automatic_isakmp_wan',
+        'is_automatic': True,
+    }
+
+    mocker.patch.object(logic, 'api_search_post', return_value=[automatic_entry])
+    api_get = mocker.patch.object(logic, '_api_get')
+
+    entries = logic.search(match_fields=['description'])
+
+    assert entries == [automatic_entry]
+    assert logic.raw == automatic_entry
+    api_get.assert_not_called()

--- a/plugins/module_utils/main/nat_source.py
+++ b/plugins/module_utils/main/nat_source.py
@@ -63,6 +63,11 @@ class SNat(BaseModule):
                     "You need to provide an 'target' to create a source-nat rule!"
                 )
 
+        if not is_unset(self.p['protocol']):
+            # OPNsense stores/returns 'protocol' lowercase (model enforces 'ChangeCase: lower') -
+            # normalize here so diff-comparisons against the existing entry don't falsely report a change
+            self.p['protocol'] = self.p['protocol'].lower()
+
         self._build_log_name()
         self.find(match_fields=self.p['match_fields'])
 

--- a/plugins/module_utils/main/nat_source.py
+++ b/plugins/module_utils/main/nat_source.py
@@ -64,9 +64,9 @@ class SNat(BaseModule):
                 )
 
         if not is_unset(self.p['protocol']):
-            # OPNsense stores/returns 'protocol' lowercase (model enforces 'ChangeCase: lower') -
-            # normalize here so diff-comparisons against the existing entry don't falsely report a change
-            self.p['protocol'] = self.p['protocol'].lower()
+            # OPNsense returns protocol values uppercase on existing source-NAT rules.
+            # Normalize user input to that canonical form so re-runs stay idempotent.
+            self.p['protocol'] = self.p['protocol'].upper()
 
         self._build_log_name()
         self.find(match_fields=self.p['match_fields'])

--- a/plugins/module_utils/main/nat_source.py
+++ b/plugins/module_utils/main/nat_source.py
@@ -14,10 +14,11 @@ class SNat(BaseModule):
         'add': 'add_rule',
         'del': 'del_rule',
         'set': 'set_rule',
-        'search': 'get',
+        'search': 'search_rule',
+        'detail': 'get_rule',
         'toggle': 'toggle_rule',
     }
-    API_KEY_PATH = 'filter.snatrules.rule'
+    API_KEY_PATH = 'rule'
     API_MOD = 'firewall'
     API_CONT = 'source_nat'
     FIELDS_CHANGE = [

--- a/plugins/module_utils/main/nat_source.py
+++ b/plugins/module_utils/main/nat_source.py
@@ -64,9 +64,13 @@ class SNat(BaseModule):
                 )
 
         if not is_unset(self.p['protocol']):
-            # OPNsense returns protocol values uppercase on existing source-NAT rules.
-            # Normalize user input to that canonical form so re-runs stay idempotent.
-            self.p['protocol'] = self.p['protocol'].upper()
+            # OPNsense returns source-NAT protocols mostly uppercase, except 'any' which
+            # stays lowercase. Normalize to the API's canonical values for idempotency.
+            if self.p['protocol'].lower() == 'any':
+                self.p['protocol'] = 'any'
+
+            else:
+                self.p['protocol'] = self.p['protocol'].upper()
 
         self._build_log_name()
         self.find(match_fields=self.p['match_fields'])

--- a/plugins/module_utils/main/nat_source_pytest.py
+++ b/plugins/module_utils/main/nat_source_pytest.py
@@ -1,0 +1,7 @@
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_source import SNat
+
+
+def test_nat_source_uses_rule_endpoints():
+    assert SNat.CMDS['search'] == 'search_rule'
+    assert SNat.CMDS['detail'] == 'get_rule'
+    assert SNat.API_KEY_PATH == 'rule'

--- a/plugins/module_utils/main/nat_source_pytest.py
+++ b/plugins/module_utils/main/nat_source_pytest.py
@@ -1,7 +1,44 @@
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_source import SNat
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.test.mock_pytest import \
+    MockAnsibleModule
 
 
 def test_nat_source_uses_rule_endpoints():
     assert SNat.CMDS['search'] == 'search_rule'
     assert SNat.CMDS['detail'] == 'get_rule'
     assert SNat.API_KEY_PATH == 'rule'
+
+
+def test_nat_source_normalizes_protocol_before_matching(mocker):
+    module = MockAnsibleModule()
+    module.params.update({
+        'state': 'present',
+        'enabled': True,
+        'sequence': 1,
+        'no_nat': False,
+        'interface': 'lan',
+        'target': '192.168.0.5',
+        'target_port': '',
+        'description': 'ANSIBLE_TEST_SNAT',
+        'ip_protocol': 'inet',
+        'protocol': 'TCP',
+        'source_invert': False,
+        'source_net': 'any',
+        'source_port': '',
+        'destination_invert': False,
+        'destination_net': '192.168.0.1',
+        'destination_port': '',
+        'log': False,
+        'static_port': False,
+        'match_fields': ['description'],
+    })
+    result = {'changed': False, 'diff': {'before': {}, 'after': {}}}
+    snat = SNat(module=module, result=result)
+
+    find = mocker.patch.object(snat, 'find')
+    mocker.patch.object(snat, '_base_check')
+
+    snat.check()
+
+    assert snat.p['protocol'] == 'tcp'
+    find.assert_called_once_with(match_fields=['description'])

--- a/plugins/module_utils/main/nat_source_pytest.py
+++ b/plugins/module_utils/main/nat_source_pytest.py
@@ -9,7 +9,7 @@ def test_nat_source_uses_rule_endpoints():
     assert SNat.API_KEY_PATH == 'rule'
 
 
-def test_nat_source_normalizes_protocol_before_matching(mocker):
+def test_nat_source_normalizes_protocol_to_existing_opnsense_case(mocker):
     module = MockAnsibleModule()
     module.params.update({
         'state': 'present',
@@ -35,10 +35,65 @@ def test_nat_source_normalizes_protocol_before_matching(mocker):
     result = {'changed': False, 'diff': {'before': {}, 'after': {}}}
     snat = SNat(module=module, result=result)
 
-    find = mocker.patch.object(snat, 'find')
+    mocker.patch.object(snat, 'find')
     mocker.patch.object(snat, '_base_check')
 
     snat.check()
 
-    assert snat.p['protocol'] == 'tcp'
-    find.assert_called_once_with(match_fields=['description'])
+    assert snat.p['protocol'] == 'TCP'
+
+
+def test_nat_source_existing_uppercase_protocol_stays_idempotent(mocker):
+    module = MockAnsibleModule()
+    module.params.update({
+        'state': 'present',
+        'enabled': True,
+        'sequence': 1,
+        'no_nat': False,
+        'interface': 'lan',
+        'target': '192.168.0.5',
+        'target_port': '',
+        'description': 'ANSIBLE_TEST_SNAT',
+        'ip_protocol': 'inet',
+        'protocol': 'tcp',
+        'source_invert': False,
+        'source_net': 'any',
+        'source_port': '',
+        'destination_invert': False,
+        'destination_net': '192.168.0.1',
+        'destination_port': '',
+        'log': False,
+        'static_port': False,
+        'match_fields': ['description'],
+    })
+    result = {'changed': False, 'diff': {'before': {}, 'after': {}}}
+    snat = SNat(module=module, result=result)
+
+    snat.rule = {
+        'uuid': 'rule-1',
+        'enabled': True,
+        'sequence': 1,
+        'no_nat': False,
+        'interface': 'lan',
+        'target': '192.168.0.5',
+        'target_port': '',
+        'description': 'ANSIBLE_TEST_SNAT',
+        'ip_protocol': 'inet',
+        'protocol': 'TCP',
+        'source_invert': False,
+        'source_net': 'any',
+        'source_port': '',
+        'destination_invert': False,
+        'destination_net': '192.168.0.1',
+        'destination_port': '',
+        'log': False,
+        'static_port': False,
+    }
+
+    mocker.patch.object(snat, 'find')
+    mocker.patch.object(snat, '_base_check')
+
+    snat.check()
+    snat._base_update(enable_switch=False)
+
+    assert result['changed'] is False

--- a/plugins/module_utils/main/nat_source_pytest.py
+++ b/plugins/module_utils/main/nat_source_pytest.py
@@ -97,3 +97,37 @@ def test_nat_source_existing_uppercase_protocol_stays_idempotent(mocker):
     snat._base_update(enable_switch=False)
 
     assert result['changed'] is False
+
+
+def test_nat_source_any_protocol_stays_lowercase(mocker):
+    module = MockAnsibleModule()
+    module.params.update({
+        'state': 'present',
+        'enabled': True,
+        'sequence': 1,
+        'no_nat': False,
+        'interface': 'lan',
+        'target': '192.168.0.5',
+        'target_port': '',
+        'description': 'ANSIBLE_TEST_SNAT',
+        'ip_protocol': 'inet',
+        'protocol': 'ANY',
+        'source_invert': False,
+        'source_net': 'any',
+        'source_port': '',
+        'destination_invert': False,
+        'destination_net': '192.168.0.1',
+        'destination_port': '',
+        'log': False,
+        'static_port': False,
+        'match_fields': ['description'],
+    })
+    result = {'changed': False, 'diff': {'before': {}, 'after': {}}}
+    snat = SNat(module=module, result=result)
+
+    mocker.patch.object(snat, 'find')
+    mocker.patch.object(snat, '_base_check')
+
+    snat.check()
+
+    assert snat.p['protocol'] == 'any'


### PR DESCRIPTION
Fixes #433

## Summary
OPNsense 26.7 changed the `source_nat` API layout. The module currently still queries `get`, which now returns the general mode settings instead of the rule list.

This switches the module to the rule-specific endpoints and updates the response path accordingly:
- use `search_rule` for listing/matching rules
- use `get_rule` for rule details
- use `rule` as `API_KEY_PATH`

## Problem
On OPNsense 26.7 the current code fails with an `invalid API_KEY_PATH` error because it expects `filter.snatrules.rule` in the response from `/api/firewall/source_nat/get`, but that endpoint no longer returns the rules.

## Result
The module can match existing source NAT rules again on OPNsense 26.7.