### PR TITLE
fix: resolve existing IPsec auth connections before matching

### DIFF
--- a/plugins/module_utils/main/ipsec_auth.py
+++ b/plugins/module_utils/main/ipsec_auth.py
@@ -79,9 +79,10 @@ class BaseAuth(BaseModule):
                     'authentication method!'
                 )
 
-        self._base_check()
-
         if self.p['state'] == 'present':
+            if self.existing_entries is None:
+                self.existing_entries = self._call_search()
+
             self.find_single_link(
                 field='connection',
                 existing=self.existing_conns,
@@ -97,6 +98,8 @@ class BaseAuth(BaseModule):
                     # if neither a local nor a remote authentication-entry exists ->
                     #   we must create one first to get the relevant entries
                     pass
+
+        self._base_check()
 
     def create(self) -> None:
         if self.p['authentication'] == 'pubkey' and not self.pubkey_link_found:

--- a/plugins/module_utils/main/ipsec_auth_pytest.py
+++ b/plugins/module_utils/main/ipsec_auth_pytest.py
@@ -1,0 +1,40 @@
+import pytest
+
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.module import BaseModule
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.ipsec_auth import BaseAuth
+
+
+@pytest.fixture
+def auth(mocker):
+    mocker.patch.object(BaseModule, '__init__', return_value=None)
+    instance = BaseAuth(m=None, r={}, s=None, f=None)
+    instance.m = mocker.Mock()
+    instance.m.fail_json.side_effect = AssertionError
+    instance.p = {
+        'state': 'present',
+        'connection': 'TEST_CONN',
+        'authentication': 'psk',
+        'certificates': None,
+        'public_keys': None,
+        'eap_id': None,
+    }
+    instance.existing_entries = None
+    instance.existing_conns = {'dummy': {'description': 'TEST_CONN'}}
+    return instance
+
+
+def test_check_resolves_connection_before_matching(mocker, auth):
+    calls = []
+
+    mocker.patch.object(auth, '_call_search', side_effect=lambda: calls.append('_call_search') or {})
+    mocker.patch.object(
+        auth,
+        'find_single_link',
+        side_effect=lambda **kwargs: calls.append('find_single_link'),
+    )
+    mocker.patch.object(auth, '_base_check', side_effect=lambda: calls.append('_base_check'))
+
+    auth.check()
+
+    assert calls == ['_call_search', 'find_single_link', '_base_check']

--- a/tests/ipsec_auth_local.yml
+++ b/tests/ipsec_auth_local.yml
@@ -146,6 +146,14 @@
         opn2.changed
       when: not ansible_check_mode
 
+    - name: Listing after idempotent re-run
+      oxlorg.opnsense.list:
+      register: opn2_list
+      failed_when: >
+        'data' not in opn2_list or
+        opn2_list.data | length != 1
+      when: not ansible_check_mode
+
     - name: Changing 1 (pubkey)
       oxlorg.opnsense.ipsec_auth_local:
         name: 'ANSIBLE_TEST_1_1'

--- a/tests/ipsec_auth_remote.yml
+++ b/tests/ipsec_auth_remote.yml
@@ -146,6 +146,14 @@
         opn2.changed
       when: not ansible_check_mode
 
+    - name: Listing after idempotent re-run
+      oxlorg.opnsense.list:
+      register: opn2_list
+      failed_when: >
+        'data' not in opn2_list or
+        opn2_list.data | length != 1
+      when: not ansible_check_mode
+
     - name: Changing 1 (pubkey)
       oxlorg.opnsense.ipsec_auth_remote:
         name: 'ANSIBLE_TEST_1_1'


### PR DESCRIPTION
## Summary
Existing IPsec auth entries store their `connection` reference as the linked connection UUID. During `check()`, the module currently runs `_base_check()` before loading the existing auth entries and before resolving the configured `connection` from its display name to that UUID.

This causes the match step to compare the configured connection name with the existing UUID and can make an already existing auth entry look absent. Re-running the task may then create duplicate local/remote auth objects.

## Fix
Load the existing auth entries first, resolve the `connection` link, and only then run `_base_check()`.

## Result
Repeated runs match existing IPsec auth entries correctly instead of creating duplicates.