### PR TITLE
feat: expose match_fields for IPsec auth modules

### DIFF
--- a/plugins/module_utils/defaults/ipsec_auth.py
+++ b/plugins/module_utils/defaults/ipsec_auth.py
@@ -1,4 +1,9 @@
 IPSEC_AUTH_MOD_ARGS = dict(
+    match_fields=dict(
+        type='list', required=False, elements='str',
+        choices=['name', 'connection', 'round', 'authentication', 'id', 'eap_id'],
+        description='Fields used to match existing auth entries before updating them'
+    ),
     name=dict(
         type='str', required=True, aliases=['description', 'desc'],
         description='Unique name to identify the entry'

--- a/plugins/module_utils/defaults/ipsec_auth_defaults_pytest.py
+++ b/plugins/module_utils/defaults/ipsec_auth_defaults_pytest.py
@@ -1,2 +1,5 @@
-def test_placeholder():
+def test_match_fields_is_exposed():
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.ipsec_auth import IPSEC_AUTH_MOD_ARGS
+
+    assert 'match_fields' in IPSEC_AUTH_MOD_ARGS
+    assert IPSEC_AUTH_MOD_ARGS['match_fields']['type'] == 'list'


### PR DESCRIPTION
## Summary
The `ipsec_auth_local` and `ipsec_auth_remote` modules already support custom matching logic in the implementation, but `match_fields` is currently not exposed in the module arguments.

This adds the missing module argument so callers can control how existing auth entries are matched before update.

## Result
IPsec auth modules can use explicit `match_fields` just like other modules with customizable matching behavior.