### PR TITLE
feat: add firewall categories to alias and rules

### DIFF
--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -7,6 +7,10 @@ ALIAS_MOD_ARGS = dict(
     description=dict(
         type='str', required=False, default='', aliases=['desc'],
     ),
+    categories=dict(
+        type='list', required=False, default=[], elements='str',
+        description='List of firewall alias categories by display name'
+    ),
     content=dict(
         type='list', required=False, default=[], aliases=['c', 'cont'], elements='str',
     ),

--- a/plugins/module_utils/defaults/alias_defaults_pytest.py
+++ b/plugins/module_utils/defaults/alias_defaults_pytest.py
@@ -1,2 +1,5 @@
-def test_placeholder():
+def test_categories_is_exposed():
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.alias import ALIAS_MOD_ARGS
+
+    assert 'categories' in ALIAS_MOD_ARGS
+    assert ALIAS_MOD_ARGS['categories']['type'] == 'list'

--- a/plugins/module_utils/defaults/rule.py
+++ b/plugins/module_utils/defaults/rule.py
@@ -153,6 +153,10 @@ RULE_MOD_ARGS = dict(
         type='str', required=False, default=RULE_DEFAULTS['gateway'],
         aliases=RULE_MOD_ARG_ALIASES['gateway'], description='Existing gateway to use'
     ),
+    categories=dict(
+        type='list', elements='str', required=False, default=[],
+        description='List of firewall rule categories by display name'
+    ),
     replyto=dict(
         type='str', required=False, default=RULE_DEFAULTS['replyto'],
         aliases=RULE_MOD_ARG_ALIASES['replyto'],

--- a/plugins/module_utils/defaults/rule_defaults_pytest.py
+++ b/plugins/module_utils/defaults/rule_defaults_pytest.py
@@ -1,3 +1,6 @@
-def test_placeholder():
+def test_categories_is_exposed():
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.rule import \
         RULE_MOD_ARGS
+
+    assert 'categories' in RULE_MOD_ARGS
+    assert RULE_MOD_ARGS['categories']['type'] == 'list'

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -25,7 +25,7 @@ class Alias(BaseModule):
     API_KEY_PATH = 'alias.aliases.alias'
     API_MOD = 'firewall'
     API_CONT = 'alias'
-    FIELDS_CHANGE = ['content', 'description', 'statistics']
+    FIELDS_CHANGE = ['content', 'description', 'statistics', 'categories']
     FIELDS_ALL = ['name', 'type', 'enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)
     FIELDS_ALL.extend([
@@ -43,6 +43,7 @@ class Alias(BaseModule):
     FIELDS_TYPING = {
         'bool': ['enabled', 'statistics'],
         'select': ['type', 'interface'],
+        'list_value': ['categories'],
     }
     EXIST_ATTR = 'alias'
     JOIN_CHAR = '\n'
@@ -55,6 +56,7 @@ class Alias(BaseModule):
     ):
         BaseModule.__init__(self=self, m=module, r=result, s=session, f=fail, multi=multi)
         self.alias = {}
+        self.existing_categories = None
 
     def check(self) -> None:
         if self.p['type'] == 'urltable':
@@ -137,6 +139,36 @@ class Alias(BaseModule):
         else:
             self.m.warn(msg)
             raise ModuleSoftError
+
+    def _get_category_selection(self) -> dict:
+        if isinstance(self.existing_categories, dict):
+            return self.existing_categories
+
+        if isinstance(self.existing_entries, dict):
+            if self.exists and self.field_pk in self.alias and self.alias[self.field_pk] in self.existing_entries:
+                return self.existing_entries[self.alias[self.field_pk]].get('categories', {})
+
+            for entry in self.existing_entries.values():
+                if isinstance(entry, dict) and 'categories' in entry:
+                    return entry['categories']
+
+        return {}
+
+    def build_request(self) -> dict:
+        raw_request = self._base_build_request()
+
+        if not is_unset(self.p['categories']):
+            selection = self._get_category_selection()
+            categories = self.p['categories'].copy()
+            self.find_multiple_links(
+                field='categories',
+                existing=selection,
+                existing_field_id='value',
+            )
+            raw_request['alias']['categories'] = self.RESP_JOIN_CHAR.join(self.p['categories'])
+            self.p['categories'] = categories
+
+        return raw_request
 
     def get_existing(self) -> list:
         return filter_builtin_alias(

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -154,6 +154,9 @@ class Alias(BaseModule):
 
         return {}
 
+    def get_category_selection(self) -> dict:
+        return self._get_category_selection()
+
     def build_request(self) -> dict:
         raw_request = self._base_build_request()
 

--- a/plugins/module_utils/main/firewall_categories_pytest.py
+++ b/plugins/module_utils/main/firewall_categories_pytest.py
@@ -67,7 +67,7 @@ def test_alias_multi_callbacks_cache_categories():
             'uuid-b': {'name': 'bogons', 'categories': {'cat-2': {'value': 'Builtin'}}},
         },
         simplify_existing=lambda entry: entry,
-        _get_category_selection=lambda: {'cat-1': {'value': 'Ops'}},
+        get_category_selection=lambda: {'cat-1': {'value': 'Ops'}},
     )
 
     cache = AliasMultiCallbacks.get_existing(meta_entry)
@@ -87,7 +87,7 @@ def test_rule_multi_callbacks_cache_categories():
             'uuid-r1': {'description': 'Allow VPN', 'categories': {'cat-1': {'value': 'VPN'}}},
         },
         simplify_existing=lambda entry: entry,
-        _get_category_selection=lambda: {'cat-1': {'value': 'VPN'}},
+        get_category_selection=lambda: {'cat-1': {'value': 'VPN'}},
     )
 
     cache = RuleMultiCallbacks.get_existing(meta_entry)

--- a/plugins/module_utils/main/firewall_categories_pytest.py
+++ b/plugins/module_utils/main/firewall_categories_pytest.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.alias import Alias
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.rule import Rule
+from ansible_collections.oxlorg.opnsense.plugins.modules.alias_multi import \
+    MultiCallbacks as AliasMultiCallbacks
+from ansible_collections.oxlorg.opnsense.plugins.modules.rule_multi import \
+    MultiCallbacks as RuleMultiCallbacks
+
+
+def test_alias_build_request_uses_cached_category_selection():
+    alias = Alias.__new__(Alias)
+    alias.p = {'categories': ['Ops', 'VPN']}
+    alias.r = {'diff': {'before': {}, 'after': {}}}
+    alias.RESP_JOIN_CHAR = ','
+    alias.existing_categories = {
+        'uuid-ops': {'value': 'Ops'},
+        'uuid-vpn': {'value': 'VPN'},
+    }
+    alias._base_build_request = lambda: {'alias': {}}
+
+    def fake_find_multiple_links(field, existing, existing_field_id, **_kwargs):
+        assert field == 'categories'
+        assert existing == alias.existing_categories
+        assert existing_field_id == 'value'
+        alias.p[field] = ['uuid-ops', 'uuid-vpn']
+        return True
+
+    alias.find_multiple_links = fake_find_multiple_links
+
+    request = alias.build_request()
+
+    assert request == {'alias': {'categories': 'uuid-ops,uuid-vpn'}}
+    assert alias.p['categories'] == ['Ops', 'VPN']
+
+
+def test_rule_build_request_uses_cached_category_selection():
+    rule = Rule.__new__(Rule)
+    rule.p = {'categories': ['Allow', 'Critical']}
+    rule.r = {'diff': {'before': {}, 'after': {}}}
+    rule.RESP_JOIN_CHAR = ','
+    rule.existing_categories = {
+        'uuid-allow': {'value': 'Allow'},
+        'uuid-critical': {'value': 'Critical'},
+    }
+    rule._base_build_request = lambda: {'rule': {}}
+
+    def fake_find_multiple_links(field, existing, existing_field_id, **_kwargs):
+        assert field == 'categories'
+        assert existing == rule.existing_categories
+        assert existing_field_id == 'value'
+        rule.p[field] = ['uuid-allow', 'uuid-critical']
+        return True
+
+    rule.find_multiple_links = fake_find_multiple_links
+
+    request = rule.build_request()
+
+    assert request == {'rule': {'categories': 'uuid-allow,uuid-critical'}}
+    assert rule.p['categories'] == ['Allow', 'Critical']
+
+
+def test_alias_multi_callbacks_cache_categories():
+    meta_entry = SimpleNamespace(
+        search=lambda: {
+            'uuid-a': {'name': 'custom_alias', 'categories': {'cat-1': {'value': 'Ops'}}},
+            'uuid-b': {'name': 'bogons', 'categories': {'cat-2': {'value': 'Builtin'}}},
+        },
+        simplify_existing=lambda entry: entry,
+        _get_category_selection=lambda: {'cat-1': {'value': 'Ops'}},
+    )
+
+    cache = AliasMultiCallbacks.get_existing(meta_entry)
+    entry = SimpleNamespace(existing_entries=None, existing_categories=None)
+    AliasMultiCallbacks.set_existing(entry, cache)
+
+    assert cache['main'] == [{'name': 'custom_alias', 'categories': {'cat-1': {'value': 'Ops'}}, 'uuid': 'uuid-a'}]
+    assert cache['categories'] == {'cat-1': {'value': 'Ops'}}
+    assert entry.existing_entries == cache['main']
+    assert entry.existing_categories == cache['categories']
+
+
+def test_rule_multi_callbacks_cache_categories():
+    meta_entry = SimpleNamespace(
+        p={'match_fields': ['description']},
+        search=lambda match_fields: {
+            'uuid-r1': {'description': 'Allow VPN', 'categories': {'cat-1': {'value': 'VPN'}}},
+        },
+        simplify_existing=lambda entry: entry,
+        _get_category_selection=lambda: {'cat-1': {'value': 'VPN'}},
+    )
+
+    cache = RuleMultiCallbacks.get_existing(meta_entry)
+    entry = SimpleNamespace(existing_entries=None, existing_categories=None)
+    RuleMultiCallbacks.set_existing(entry, cache)
+
+    assert cache['main'] == [{'description': 'Allow VPN', 'categories': {'cat-1': {'value': 'VPN'}}, 'uuid': 'uuid-r1'}]
+    assert cache['categories'] == {'cat-1': {'value': 'VPN'}}
+    assert entry.existing_entries == cache['main']
+    assert entry.existing_categories == cache['categories']

--- a/plugins/module_utils/main/nat_one_to_one.py
+++ b/plugins/module_utils/main/nat_one_to_one.py
@@ -2,6 +2,8 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import \
     Session
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.translate import \
+    get_key_by_value_from_selection
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.validate import \
     is_unset
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.module import BaseModule
@@ -21,7 +23,7 @@ class OneToOne(BaseModule):
     API_CONT = 'one_to_one'
     FIELDS_CHANGE = [
         'log', 'sequence', 'interface', 'type', 'source_net', 'source_invert', 'destination_net', 'destination_invert',
-        'external', 'nat_reflection', 'description'
+        'external', 'nat_reflection', 'description', 'categories'
 
     ]
     FIELDS_ALL = ['enabled']
@@ -36,6 +38,7 @@ class OneToOne(BaseModule):
         'list': [],
         'select': ['interface', 'type', 'nat_reflection'],
         'int': [],
+        'list_value': ['categories'],
     }
     INT_VALIDATIONS = {
         'sequence': {'min': 1, 'max': 99999},
@@ -57,3 +60,38 @@ class OneToOne(BaseModule):
         self.find(match_fields=self.p['match_fields'])
 
         self._base_check()
+
+    def _get_category_selection(self) -> dict:
+        rules = self._search_path_handling(
+            self._api_get({
+                **self.call_cnf,
+                'command': self.CMDS['search'],
+            })
+        )
+
+        if isinstance(rules, dict):
+            if self.exists and self.field_pk in self.rule and self.rule[self.field_pk] in rules:
+                return rules[self.rule[self.field_pk]].get('categories', {})
+
+            for entry in rules.values():
+                if isinstance(entry, dict) and 'categories' in entry:
+                    return entry['categories']
+
+        return {}
+
+    def build_request(self) -> dict:
+        raw_request = self._base_build_request()
+
+        if not is_unset(self.p['categories']):
+            selection = self._get_category_selection()
+            category_ids = []
+            for category in self.p['categories']:
+                category_id = get_key_by_value_from_selection(selection=selection, value=category)
+                if category_id is None:
+                    self.m.fail_json(f"Unable to resolve rule category '{category}'")
+
+                category_ids.append(category_id)
+
+            raw_request['rule']['categories'] = self.RESP_JOIN_CHAR.join(category_ids)
+
+        return raw_request

--- a/plugins/module_utils/main/rule.py
+++ b/plugins/module_utils/main/rule.py
@@ -7,8 +7,6 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.validate im
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import Session
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.main import \
     is_unset
-from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.translate import \
-    get_key_by_value_from_selection
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.rule import \
     validate_values
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.module import BaseModule
@@ -96,6 +94,7 @@ class Rule(BaseModule):
         BaseModule.__init__(self=self, m=module, r=result, s=session, f=fail, multi=multi)
         self.rule = {}
         self.log_name = None
+        self.existing_categories = None
 
     def _build_log_name(self) -> str:
         if self.p['description'] not in [None, '']:
@@ -142,18 +141,14 @@ class Rule(BaseModule):
             raise ModuleSoftError
 
     def _get_category_selection(self) -> dict:
-        rules = self._search_path_handling(
-            self._api_get({
-                **self.call_cnf,
-                'command': self.CMDS['search'],
-            })
-        )
+        if isinstance(self.existing_categories, dict):
+            return self.existing_categories
 
-        if isinstance(rules, dict):
-            if self.exists and self.field_pk in self.rule and self.rule[self.field_pk] in rules:
-                return rules[self.rule[self.field_pk]].get('categories', {})
+        if isinstance(self.existing_entries, dict):
+            if self.exists and self.field_pk in self.rule and self.rule[self.field_pk] in self.existing_entries:
+                return self.existing_entries[self.rule[self.field_pk]].get('categories', {})
 
-            for entry in rules.values():
+            for entry in self.existing_entries.values():
                 if isinstance(entry, dict) and 'categories' in entry:
                     return entry['categories']
 
@@ -164,14 +159,13 @@ class Rule(BaseModule):
 
         if not is_unset(self.p['categories']):
             selection = self._get_category_selection()
-            category_ids = []
-            for category in self.p['categories']:
-                category_id = get_key_by_value_from_selection(selection=selection, value=category)
-                if category_id is None:
-                    self.m.fail_json(f"Unable to resolve rule category '{category}'")
-
-                category_ids.append(category_id)
-
-            raw_request['rule']['categories'] = self.RESP_JOIN_CHAR.join(category_ids)
+            categories = self.p['categories'].copy()
+            self.find_multiple_links(
+                field='categories',
+                existing=selection,
+                existing_field_id='value',
+            )
+            raw_request['rule']['categories'] = self.RESP_JOIN_CHAR.join(self.p['categories'])
+            self.p['categories'] = categories
 
         return raw_request

--- a/plugins/module_utils/main/rule.py
+++ b/plugins/module_utils/main/rule.py
@@ -5,6 +5,10 @@ from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler impor
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.validate import \
     validate_int_fields
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import Session
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.main import \
+    is_unset
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.translate import \
+    get_key_by_value_from_selection
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.rule import \
     validate_values
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.module import BaseModule
@@ -30,7 +34,7 @@ class Rule(BaseModule):
         'allow_opts', 'state_type', 'state_policy', 'state_timeout',
         'max_states', 'max_src_nodes', 'max_src_states', 'max_src_conn', 'max_src_conn_rate',
         'max_src_conn_rates', 'overload', 'adaptive_start', 'adaptive_end', 'prio', 'set_prio', 'set_prio_low',
-        'tcp_flags', 'tcp_flags_clear', 'schedule', 'tos', 'icmp_type',
+        'tcp_flags', 'tcp_flags_clear', 'schedule', 'tos', 'icmp_type', 'categories',
         'divert_to', 'shaper1', 'shaper2',
     ]
     FIELDS_ALL = ['enabled']
@@ -73,6 +77,7 @@ class Rule(BaseModule):
             'divert_to', 'shaper1', 'shaper2',
         ],
         'list': ['interface', 'tcp_flags', 'tcp_flags_clear', 'icmp_type', 'icmpv6_type'],
+        'list_value': ['categories'],
         'int': ['sequence', 'state_timeout'],
     }
     FIELDS_OPTIONAL = ['icmp_type', 'icmpv6_type']
@@ -135,3 +140,38 @@ class Rule(BaseModule):
         else:
             self.m.warn(msg)
             raise ModuleSoftError
+
+    def _get_category_selection(self) -> dict:
+        rules = self._search_path_handling(
+            self._api_get({
+                **self.call_cnf,
+                'command': self.CMDS['search'],
+            })
+        )
+
+        if isinstance(rules, dict):
+            if self.exists and self.field_pk in self.rule and self.rule[self.field_pk] in rules:
+                return rules[self.rule[self.field_pk]].get('categories', {})
+
+            for entry in rules.values():
+                if isinstance(entry, dict) and 'categories' in entry:
+                    return entry['categories']
+
+        return {}
+
+    def build_request(self) -> dict:
+        raw_request = self._base_build_request()
+
+        if not is_unset(self.p['categories']):
+            selection = self._get_category_selection()
+            category_ids = []
+            for category in self.p['categories']:
+                category_id = get_key_by_value_from_selection(selection=selection, value=category)
+                if category_id is None:
+                    self.m.fail_json(f"Unable to resolve rule category '{category}'")
+
+                category_ids.append(category_id)
+
+            raw_request['rule']['categories'] = self.RESP_JOIN_CHAR.join(category_ids)
+
+        return raw_request

--- a/plugins/module_utils/main/rule.py
+++ b/plugins/module_utils/main/rule.py
@@ -154,6 +154,9 @@ class Rule(BaseModule):
 
         return {}
 
+    def get_category_selection(self) -> dict:
+        return self._get_category_selection()
+
     def build_request(self) -> dict:
         raw_request = self._base_build_request()
 

--- a/plugins/modules/alias_multi.py
+++ b/plugins/modules/alias_multi.py
@@ -23,7 +23,9 @@ try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.alias import Alias
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.main import ensure_list
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.alias import \
-        builtin_alias, build_updatefreq
+        builtin_alias, build_updatefreq, filter_builtin_alias
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.translate import \
+        get_simple_existing
 
 except MODULE_EXCEPTIONS:
     module_dependency_error()
@@ -34,6 +36,24 @@ except MODULE_EXCEPTIONS:
 
 
 class MultiCallbacks(MultiModuleCallbacks):
+    @staticmethod
+    def get_existing(meta_entry: Alias) -> dict:
+        existing_raw = meta_entry.search()
+        return {
+            'main': filter_builtin_alias(
+                get_simple_existing(
+                    entries=existing_raw,
+                    simplify_func=meta_entry.simplify_existing,
+                )
+            ),
+            'categories': meta_entry._get_category_selection(),
+        }
+
+    @staticmethod
+    def set_existing(entry: Alias, cache: dict):
+        entry.existing_entries = cache['main']
+        entry.existing_categories = cache['categories']
+
     @staticmethod
     def build(entry: dict) -> dict:
         entry['content'] = list(map(str, ensure_list(entry['content'])))

--- a/plugins/modules/alias_multi.py
+++ b/plugins/modules/alias_multi.py
@@ -46,7 +46,7 @@ class MultiCallbacks(MultiModuleCallbacks):
                     simplify_func=meta_entry.simplify_existing,
                 )
             ),
-            'categories': meta_entry._get_category_selection(),
+            'categories': meta_entry.get_category_selection(),
         }
 
     @staticmethod

--- a/plugins/modules/nat_one_to_one.py
+++ b/plugins/modules/nat_one_to_one.py
@@ -33,6 +33,7 @@ def run_module():
         'source_invert': RULE_MOD_ARGS['source_invert'],
         'destination_net': RULE_MOD_ARGS['destination_net'],
         'destination_invert': RULE_MOD_ARGS['destination_invert'],
+        'categories': RULE_MOD_ARGS['categories'],
         'description': RULE_MOD_ARGS['description'],
         'uuid': RULE_MOD_ARGS['uuid'],
     }

--- a/plugins/modules/rule_multi.py
+++ b/plugins/modules/rule_multi.py
@@ -16,11 +16,13 @@ try:
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import \
         module_multi_wrapper
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.multi import \
-        build_multi_mod_args
+        build_multi_mod_args, MultiModuleCallbacks
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
         OPN_MOD_ARGS, RELOAD_MOD_ARG
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.rule import \
         RULE_MOD_ARGS, RULE_MATCH_FIELDS_ARG
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.translate import \
+        get_simple_existing
     from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.rule import Rule
 
 except MODULE_EXCEPTIONS:
@@ -29,6 +31,24 @@ except MODULE_EXCEPTIONS:
 
 # DOCUMENTATION = 'https://ansible-opnsense.oxl.app/modules/rule.html'
 # EXAMPLES = 'https://ansible-opnsense.oxl.app/modules/rule.html'
+
+
+class MultiCallbacks(MultiModuleCallbacks):
+    @staticmethod
+    def get_existing(meta_entry: Rule) -> dict:
+        existing_raw = meta_entry.search(match_fields=meta_entry.p['match_fields'])
+        return {
+            'main': get_simple_existing(
+                entries=existing_raw,
+                simplify_func=meta_entry.simplify_existing,
+            ),
+            'categories': meta_entry._get_category_selection(),
+        }
+
+    @staticmethod
+    def set_existing(entry: Rule, cache: dict):
+        entry.existing_entries = cache['main']
+        entry.existing_categories = cache['categories']
 
 
 def run_module():
@@ -66,6 +86,7 @@ def run_module():
         obj=Rule,
         kind='rule',
         entry_args=entry_multi_args,
+        callbacks=MultiCallbacks(),
     )
     module.exit_json(**result)
 

--- a/plugins/modules/rule_multi.py
+++ b/plugins/modules/rule_multi.py
@@ -42,7 +42,7 @@ class MultiCallbacks(MultiModuleCallbacks):
                 entries=existing_raw,
                 simplify_func=meta_entry.simplify_existing,
             ),
-            'categories': meta_entry._get_category_selection(),
+            'categories': meta_entry.get_category_selection(),
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary
This adds category support by display name for additional firewall objects:
- aliases
- filter rules
- one-to-one NAT rules

The implementation resolves category display names to the internal category identifiers before sending the API request.

## Result
Playbooks can manage firewall categories consistently across these modules without hardcoding category UUIDs.

## Note
`nat_source` category support is intentionally not part of this PR because that code currently overlaps with the separate OPNsense 26.7 compatibility fix in #440.