### PR TITLE
feat: add descriptions to IPsec PSKs

### DIFF
--- a/plugins/module_utils/main/ipsec_psk.py
+++ b/plugins/module_utils/main/ipsec_psk.py
@@ -21,10 +21,11 @@ class PreSharedKey(BaseModule):
     API_MOD = 'ipsec'
     API_CONT = 'pre_shared_keys'
     API_CONT_REL = 'service'
-    FIELDS_CHANGE = ['identity_remote', 'psk', 'type']
+    FIELDS_CHANGE = ['description', 'identity_remote', 'psk', 'type']
     FIELDS_ALL = [FIELD_ID]
     FIELDS_ALL.extend(FIELDS_CHANGE)
     FIELDS_TRANSLATE = {
+        'description': 'description',
         'identity_local': 'ident',
         'identity_remote': 'remote_ident',
         'psk': 'Key',

--- a/plugins/module_utils/main/ipsec_psk_pytest.py
+++ b/plugins/module_utils/main/ipsec_psk_pytest.py
@@ -1,0 +1,6 @@
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.ipsec_psk import PreSharedKey
+
+
+def test_ipsec_psk_supports_description():
+    assert 'description' in PreSharedKey.FIELDS_CHANGE
+    assert PreSharedKey.FIELDS_TRANSLATE['description'] == 'description'

--- a/plugins/modules/ipsec_psk.py
+++ b/plugins/modules/ipsec_psk.py
@@ -27,6 +27,10 @@ except MODULE_EXCEPTIONS:
 
 def run_module():
     module_args = dict(
+        description=dict(
+            type='str', required=False, aliases=['desc'],
+            description='Optional description shown for this pre-shared key entry.'
+        ),
         identity_local=dict(
             type='str', required=True, aliases=['identity', 'ident'],
             description='This can be either an IP address, fully qualified domain name or an email address.'

--- a/tests/ipsec_psk.yml
+++ b/tests/ipsec_psk.yml
@@ -57,6 +57,7 @@
 
     - name: Adding 1
       oxlorg.opnsense.ipsec_psk:
+        description: 'ANSIBLE_TEST_1_1'
         identity: 'ANSIBLE@TEST1'
         psk: 'my-super-secret'
       register: opn1
@@ -66,6 +67,7 @@
 
     - name: Adding 2
       oxlorg.opnsense.ipsec_psk:
+        description: 'ANSIBLE_TEST_1_2'
         identity: 'ANSIBLE@TEST2'
         identity_remote: 'ANSIBLE@TEST2B'
         psk: 'LSfmuw3oiksfhnf3uhfwqhfwjuhnakfuwgfjsnhfnh'
@@ -76,6 +78,7 @@
 
     - name: Adding 2 - nothing changed
       oxlorg.opnsense.ipsec_psk:
+        description: 'ANSIBLE_TEST_1_2'
         identity: 'ANSIBLE@TEST2'
         identity_remote: 'ANSIBLE@TEST2B'
         psk: 'LSfmuw3oiksfhnf3uhfwqhfwjuhnakfuwgfjsnhfnh'


### PR DESCRIPTION
## Summary
This adds optional `description` support to `ipsec_psk` entries.

The field is exposed in the module arguments and mapped through the PSK handler so descriptions are managed together with the rest of the entry.

## Tests
- extend the existing `tests/ipsec_psk.yml` functional test to set descriptions
- add a small unit test covering the new field mapping

## Result
Playbooks can manage the visible description of IPsec pre-shared key entries instead of only the identities and secret.