### PR TITLE
fix: nat_source should not require target/interface for existing rules

### DIFF
--- a/plugins/module_utils/main/nat_source.py
+++ b/plugins/module_utils/main/nat_source.py
@@ -51,7 +51,15 @@ class SNat(BaseModule):
         self.rule = {}
 
     def check(self) -> None:
-        if self.p['state'] == 'present':
+        self._build_log_name()
+        self.find(match_fields=self.p['match_fields'])
+
+        # 'interface' and 'target' are only required to *create* a new rule. An empty
+        # target is a valid existing state on OPNsense - it means "use the interface's
+        # own address", the default outbound-NAT behaviour - so an already-existing rule
+        # with an empty target must still be manageable (e.g. adopted via
+        # match_fields: [uuid]) without tripping this check.
+        if self.p['state'] == 'present' and not self.exists:
             if is_unset(self.p['interface']):
                 self.m.fail_json(
                     "You need to provide an 'interface' to create a source-nat rule!"
@@ -61,9 +69,6 @@ class SNat(BaseModule):
                 self.m.fail_json(
                     "You need to provide an 'target' to create a source-nat rule!"
                 )
-
-        self._build_log_name()
-        self.find(match_fields=self.p['match_fields'])
 
         if self.p['state'] == 'present':
             validate_values(module=self.m, cnf=self.p, error_func=self.m.fail_json, kind='nat')

--- a/plugins/module_utils/main/nat_source_pytest.py
+++ b/plugins/module_utils/main/nat_source_pytest.py
@@ -1,0 +1,55 @@
+import pytest
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nat_source import SNat
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.test.mock_pytest import \
+    AnsibleError, MockAnsibleModule
+
+
+BASE_PARAMS = {
+    'state': 'present',
+    'enabled': True,
+    'sequence': 1,
+    'no_nat': False,
+    'interface': '',
+    'target': '',
+    'target_port': '',
+    'description': 'ANSIBLE_TEST_SNAT',
+    'ip_protocol': 'inet',
+    'protocol': '',
+    'source_invert': False,
+    'source_net': 'any',
+    'source_port': '',
+    'destination_invert': False,
+    'destination_net': '192.168.0.1',
+    'destination_port': '',
+    'log': False,
+    'static_port': False,
+    'match_fields': ['uuid'],
+}
+
+
+def _build_snat(mocker, exists: bool) -> SNat:
+    module = MockAnsibleModule()
+    module.params.update(BASE_PARAMS)
+    result = {'changed': False, 'diff': {'before': {}, 'after': {}}}
+    snat = SNat(module=module, result=result)
+
+    mocker.patch.object(snat, 'find', side_effect=lambda **kwargs: setattr(snat, 'exists', exists))
+    mocker.patch.object(snat, '_base_check')
+
+    return snat
+
+
+def test_check_requires_target_and_interface_when_creating(mocker):
+    snat = _build_snat(mocker, exists=False)
+
+    with pytest.raises(AnsibleError):
+        snat.check()
+
+
+def test_check_allows_empty_target_on_existing_rule(mocker):
+    # simulates adopting an already-existing rule (e.g. match_fields: [uuid]) that has
+    # an empty target - a valid state meaning "use the interface's own address"
+    snat = _build_snat(mocker, exists=True)
+
+    snat.check()


### PR DESCRIPTION
## Problem
`check()` in `nat_source` requires `interface` and `target` whenever `state=present`, before it even checks whether the rule already exists. An empty `target` is a normal, valid configuration on OPNsense (it means "use the interface's own address", the default outbound-NAT behaviour), so this makes it impossible to adopt or manage an already-existing rule that has an empty target via `match_fields` (e.g. `[uuid]`) - even though there's nothing actually wrong with it.

Fixes #449

## Fix
Moved the check to run after `find()`, and only require `interface`/`target` when the rule doesn't already exist (`not self.exists`). Same pattern as #441 for ipsec_auth.

## Testing
Added `nat_source_pytest.py` covering both cases (fails when creating without target/interface, succeeds when adopting an existing rule with an empty target). Full suite passes locally.

Ran into this bringing my own OPNsense box's outbound NAT rules under Ansible management.