### PR TITLE
interface_assignment interface

### DIFF
--- a/docs/source/modules/interface.rst
+++ b/docs/source/modules/interface.rst
@@ -32,6 +32,11 @@ Interface
 Info
 ****
 
+oxlorg.opnsense.interface_assignment
+==================================
+
+This module manages interface assigned that can be found in the WEB-UI menu: 'Interfaces - Assignments'
+
 oxlorg.opnsense.interface_vlan
 ==================================
 
@@ -86,6 +91,23 @@ Definition
 **********
 
 .. include:: ../_include/param_basic.rst
+
+oxlorg.opnsense.interface_assignment
+==================================
+
+.. warning::
+
+    This feature is only available in OPNsense version >= 26.7
+
+..  csv-table:: Definition
+    :header: "Parameter", "Type", "Required", "Default", "Aliases", "Comment"
+    :widths: 15 10 10 10 10 45
+
+    "identifier","string", "false for creation,else true","\-","id","Technical identifier of the interface, used by hasync for example. "
+    "description","string","false","\-","desc","You may enter a description here for your reference (not parsed)"
+    "device","string","false ","\-","if","Device name to connect this interface to."
+    "lock","boolean","false","\-","\-","Prevent interface removal."
+    "reload","boolean","false","true","\-", .. include:: ../_include/param_reload.rst
 
 oxlorg.opnsense.interface_vlan
 ==================================
@@ -242,7 +264,7 @@ oxlorg.opnsense.interface_vlan
 ==================================
 
 .. code-block:: yaml
-
+    
     - hosts: firewalls
       connection: local
       gather_facts: false
@@ -253,36 +275,45 @@ oxlorg.opnsense.interface_vlan
     
         oxlorg.opnsense.list:
           target: 'interface_vlan'
+
+oxlorg.opnsense.interface_vlan
+==================================
+
+.. code-block:: yaml
+
+    - hosts: firewalls
+      connection: local
+      gather_facts: false
+      module_defaults:
+        group/oxlorg.opnsense.all:
+          firewall: 'opnsense.template.opnsense.oxl.app'
+          api_credential_file: '/home/guy/.secret/opn.key'
+    
+        oxlorg.opnsense.list:
+          target: 'interface_assignment'
     
       tasks:
-        - name: Example
-          oxlorg.opnsense.interface_vlan:
+        - name: Assign a physical device
+          oxlorg.opnsense.interface_assignment:
             description: 'example'
-            interface: 'vtnet0'
-            vlan: 100
-            # priority: 0
-            # debug: false
-            # state: 'present'
-            # reload: true
-    
-        - name: Adding VLAN
-          oxlorg.opnsense.interface_vlan:
+            interface: 'vtnet2'
+               
+        - name: Assign a VLAN
+          oxlorg.opnsense.interface_assignment:
             description: 'test1'
-            interface: 'vtnet0'
-            vlan: 100
+            interface: '"vlan0.20"'
     
         - name: Listing
           oxlorg.opnsense.list:
-          #  target: 'interface_vlan'
           register: existing_entries
     
-        - name: Printing VLANs
+        - name: Printing Assignments
           ansible.builtin.debug:
             var: existing_entries.data
     
         - name: Removing VLAN
           oxlorg.opnsense.interface_vlan:
-            description: 'test1'
+            identifier: 'opt2'
             state: 'absent'
 
 oxlorg.opnsense.interface_vxlan

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -45,6 +45,7 @@ action_groups:
     - oxlorg.opnsense.wireguard_show
     - oxlorg.opnsense.wireguard_general
   interface:
+    - oxlorg.opnsense.interface_assignment
     - oxlorg.opnsense.interface_vlan
     - oxlorg.opnsense.interface_vxlan
     - oxlorg.opnsense.interface_vip

--- a/plugins/module_utils/main/interface_assignment.py
+++ b/plugins/module_utils/main/interface_assignment.py
@@ -1,0 +1,106 @@
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import \
+    Session
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.validate import \
+    is_unset
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.module import BaseModule
+
+
+class Assignment(BaseModule):
+    FIELD_ID = 'identifier'
+    CMDS = {
+        'add': 'add_item',
+        'del': 'del_item',
+        'set': 'set_item',
+        'search': 'search_item',
+        'detail': 'get_item',
+    }
+    API_KEY_PATH = 'interface'
+    API_MOD = 'interfaces'
+    API_CONT = 'assignment'
+    FIELDS_CHANGE = ['description', 'device', 'lock']
+    FIELDS_ALL = [FIELD_ID]
+    FIELDS_ALL.extend(FIELDS_CHANGE)
+    FIELDS_TRANSLATE = {
+        'device': 'if',
+        'description': 'descr',
+    }
+    FIELDS_TYPING = {
+       'str': ['device', 'description', 'identifier'],
+       'bool': ['lock'],
+    }
+    EXIST_ATTR = 'assignment'
+
+    def __init__(self, module: AnsibleModule, result: dict, session: Session = None, fail: dict = None):
+        BaseModule.__init__(self=self, m=module, r=result, s=session, f=fail)
+        self.assignment = {}
+
+    @staticmethod
+    def get_selected_device(assignment) -> str:
+        for device, details in assignment.get('device', {}).items():
+            if details.get('selected') == 1:
+                return device
+        return None
+
+    def check(self) -> None:
+        if self.p['state'] == 'present':
+            # We dont provide an identifier on creation, so we
+            # need to first check if the device is already in use
+            # and if it is we use the previous defined identifier
+            if is_unset(self.p['identifier']):
+
+                # If we dont have the identifier set, we need the device
+                if is_unset(self.p['device']):
+                    self.m.fail_json("You need to provide a 'device' to assign the interface!")
+
+                # Get the exisiting assignments, loop through and
+                # find the if there is a matching device if there
+                # is then we aquire thats identitier
+                existing = self.get_existing()
+                for assignment in existing:
+                    device = self.get_selected_device(assignment)
+                    if device == self.p['device']:
+                        self.p['identifier'] = assignment['identifier']
+                        break
+
+                # If there isnt and exisiting assignment
+                # and the lock is not set then set it to
+                # a default
+                if is_unset(self.p['identifier']) and is_unset(self.p['lock']):
+                    self.p['lock'] = 1
+
+        elif self.p['state'] == 'absent':
+
+            # we need to have the identifier set to remove
+            if is_unset(self.p['identifier']):
+                self.m.fail_json("You need to provide a 'identifier' to delete an assigned interface!")
+
+            # Get the exisiting assignments, loop through and
+            # find the identitier if check if the device is not
+            # locked
+            existing = self.get_existing()
+            for assignment in existing:
+                if assignment['identifier'] != self.p['identifier']:
+                    continue
+                if assignment['lock']:
+                    self.m.fail_json("You need to unlock the interface before you delete an assigned interface!")
+
+        self._base_check()
+
+    def update(self) -> None:
+
+        # check if any of the parameters have not been provided
+        # and if not use the exisiting parameters
+        if is_unset(self.p['description']):
+            self.p['description'] = self.e['description']
+
+        if is_unset(self.p['device']):
+            self.p['device'] = self.get_selected_device(self.e)
+
+        if is_unset(self.p['lock']):
+            self.p['lock'] = self.e['lock']
+
+        # parse the selected device, so it can be compared
+        self.e['device'] = self.get_selected_device(self.e)
+        self._base_update(enable_switch=False)

--- a/plugins/modules/interface_assignment.py
+++ b/plugins/modules/interface_assignment.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# see: https://docs.opnsense.org/development/api/core/interfaces.html
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.handler import \
+    module_dependency_error, MODULE_EXCEPTIONS
+
+try:
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.wrapper import module_wrapper
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.defaults.main import \
+        OPN_MOD_ARGS, STATE_ONLY_MOD_ARG, RELOAD_MOD_ARG
+    from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.interface_assignment import Assignment
+
+except MODULE_EXCEPTIONS:
+    module_dependency_error()
+
+
+# DOCUMENTATION = 'https://ansible-opnsense.oxl.app/modules/interface.html'
+# EXAMPLES = 'https://ansible-opnsense.oxl.app/modules/interface.html'
+
+def run_module():
+    module_args = dict(
+        identifier=dict(
+            type='str', required=False, aliases=['id'],
+            description='Technical identifier of the interface'
+        ),
+        lock=dict(
+            type='bool', required=False,
+            description='Prevent interface removal.'
+        ),
+        description=dict(
+            type='str', required=False, aliases=['desc']
+        ),
+        device=dict(
+            type='str', required=False, aliases=['if'],
+            description='Device name to connect this interface to.'
+        ),
+        **RELOAD_MOD_ARG,
+        **STATE_ONLY_MOD_ARG,
+        **OPN_MOD_ARGS,
+    )
+
+    result = dict(
+        changed=False,
+        diff={
+            'before': {},
+            'after': {},
+        }
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    module_wrapper(Assignment(module=module, result=result))
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/list.py
+++ b/plugins/modules/list.py
@@ -51,7 +51,7 @@ TARGETS = [
     'haproxy_maintenance', 'haproxy_cpu', 'haproxy_user', 'haproxy_group', 'haproxy_acl', 'haproxy_action',
     'haproxy_lua', 'haproxy_fcgi', 'haproxy_errorfile', 'haproxy_mailer', 'haproxy_mapfile',
     'haproxy_resolver', 'haproxy_backend', 'haproxy_frontend', 'haproxy_healthcheck', 'haproxy_server',
-    'wazuh_agent', 'nut',
+    'wazuh_agent', 'nut', 'interface_assignment',
 ]
 
 
@@ -685,6 +685,10 @@ def run_module():
         elif target == 'nut':
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nut import \
                 Nut as Target_Obj
+
+        elif target == 'interface_assignment':
+            from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.interface_assignment import \
+                Assignment as Target_Obj
 
     except AttributeError:
         module_dependency_error()

--- a/plugins/modules/reload.py
+++ b/plugins/modules/reload.py
@@ -58,6 +58,7 @@ def run_module():
                 'nat_one_to_one',
                 'nat_destination',
                 'nut',
+                'interface_assignment',
             ],
             description='What part of the running config should be reloaded'
         ),
@@ -201,6 +202,10 @@ def run_module():
         elif target == 'nut':
             from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.nut import \
                 Nut as Target_Obj
+
+        elif target == 'interface_assignment':
+            from ansible_collections.oxlorg.opnsense.plugins.module_utils.main.interface_assignment import \
+                Assignment as Target_Obj
 
     except MODULE_EXCEPTIONS:
         module_dependency_error()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -120,6 +120,7 @@ run_test_soft 'wireguard_peer' 1
 run_test_soft 'wireguard_server' 1
 run_test_soft 'wireguard_general' 1
 run_test_soft 'wireguard_show' 1
+run_test_soft 'interface_assignment' 1
 run_test_soft 'interface_vlan' 1
 run_test_soft 'interface_vxlan' 1
 run_test_soft 'interface_vip' 1

--- a/tests/interface_assignment.yml
+++ b/tests/interface_assignment.yml
@@ -1,0 +1,113 @@
+---
+
+- name: Testing Interface Assignment
+  hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/oxlorg.opnsense.all:
+      firewall: "{{ lookup('ansible.builtin.env', 'TEST_FIREWALL') }}"
+      api_credential_file: "{{ lookup('ansible.builtin.env', 'TEST_API_KEY') }}"
+      ssl_verify: false
+      # match_fields: ['description']
+
+    oxlorg.opnsense.list:
+      target: 'interface_assignment'
+
+  environment:
+    HTTPS_PROXY: "{{ lookup('ansible.builtin.env', 'TEST_PROXY') | default('') }}"
+
+  tasks:
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn_pre1
+      failed_when: >
+        'data' not in opn_pre1 or
+        opn_pre1.data | length != 0
+
+    - name: Removing - does not exist
+      oxlorg.opnsense.interface_assignment:
+        identifier: "opt1"
+        state: 'absent'
+      register: opn_pre2
+      failed_when: >
+        opn_pre2.failed or
+        opn_pre2.changed
+
+    - name: Adding 1 - failing because of invalid value
+      oxlorg.opnsense.interface_assignment:
+        device: "INVALID"
+      register: opn_fail1
+      failed_when: not opn_fail1.failed
+   
+    - name: Adding 1
+      oxlorg.opnsense.interface_assignment:
+        description: "TEST_INTERFACE_1"
+        device: "vtnet0"
+      register: opn1
+      failed_when: >
+        opn1.failed or
+        not opn1.changed
+
+    - name: Changing 1
+      oxlorg.opnsense.interface_assignment:
+        identifier: "opt1"
+        description: "TEST_INTERFACE_1_CHANGED"
+      register: opn9
+      failed_when: >
+        opn9.failed or
+        not opn9.changed
+   
+
+    - name: Adding 2
+      oxlorg.opnsense.interface_assignment:
+        description: "TEST_INTERFACE_2"
+        device: "vtnet1"
+      register: opn5
+      failed_when: >
+        opn5.failed or
+        not opn5.changed
+
+    - name: Adding 2 - nothing changed
+      oxlorg.opnsense.interface_assignment:
+        description: "TEST_INTERFACE_2"
+        device: "vtnet1"
+      register: opn6
+      failed_when: >
+        opn6.failed or
+        opn6.changed
+      when: not ansible_check_mode
+
+    - name: Removing 2
+      oxlorg.opnsense.interface_assignment:
+        identifier: "opt2"
+        state: 'absent'
+      register: opn7
+      failed_when: >
+        opn7.failed or
+        not opn7.changed
+      when: not ansible_check_mode
+
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn8
+      failed_when: >
+        'data' not in opn8 or
+        opn8.data | length != 1
+      when: not ansible_check_mode
+
+    - name: Cleanup
+      oxlorg.opnsense.interface_assignment:
+        identifier: "{{ index }}"
+        state: 'absent'
+      loop:
+        - 'opt1'
+        - 'opt2'
+      when: not ansible_check_mode
+
+    - name: Listing
+      oxlorg.opnsense.list:
+      register: opn_clean1
+      failed_when: >
+        'data' not in opn_clean1 or
+        opn_clean1.data | length != 0
+      when: not ansible_check_mode


### PR DESCRIPTION
Starting in OPNSense 26.7, there has been an interface to assign the interface "/api/interfaces/assignment" I have added a module to access this.

it will allow you to select a device, set a description and sets its lock state, on creation it will create the next available "opt" identifier, which you can use to update or delete the assignment.  

You can updated or delete existing "wan" and "lan" assignments, but you cannot create them, this is a limitation of the OPNSense controller. 

