### PR TITLE
fix(route): support both the pre- and post-26.1.10 enable switch

### DIFF
--- a/plugins/module_utils/main/route.py
+++ b/plugins/module_utils/main/route.py
@@ -2,6 +2,8 @@ from ipaddress import ip_network
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.main import \
+    is_true, to_digit
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.helper.translate import \
     simplify_translate
 from ansible_collections.oxlorg.opnsense.plugins.module_utils.base.api import \
@@ -33,6 +35,19 @@ class Route(BaseModule):
     }
     EXIST_ATTR = 'route'
 
+    # OPNsense 26.1.10 renamed the static-route model's inverted 'disabled'
+    # boolean to a plain 'enabled' one - opnsense/core#10027, which bumped the
+    # Routes model from 1.0.0 to 1.0.1 and migrated existing entries. Both
+    # serialisations are in the field, so this module can hardcode neither:
+    #   * reading  - whichever of the two the API returned is normalised to the
+    #                module's 'enabled' semantics, inverting only for 'disabled'.
+    #   * writing  - both keys are sent. OPNsense's BaseField::setNodes() walks
+    #                its *own* model items and picks the matching keys out of the
+    #                payload, so the key the running model does not define is
+    #                ignored rather than rejected.
+    API_FIELD_ENABLED = 'enabled'
+    API_FIELD_DISABLED = 'disabled'
+
     def __init__(self, module: AnsibleModule, result: dict, session: Session = None, fail: dict = None):
         BaseModule.__init__(self=self, m=module, r=result, s=session, f=fail)
         self.route = {}
@@ -47,6 +62,12 @@ class Route(BaseModule):
         self._base_check()
 
     def simplify_existing(self, route: dict) -> dict:
+        route = dict(route)
+
+        if self.API_FIELD_ENABLED not in route and self.API_FIELD_DISABLED in route:
+            # OPNsense < 26.1.10
+            route[self.API_FIELD_ENABLED] = not is_true(route.pop(self.API_FIELD_DISABLED))
+
         simple = simplify_translate(
             existing=route,
             typing=self.FIELDS_TYPING,
@@ -56,3 +77,11 @@ class Route(BaseModule):
             simple['gateway'] = simple['gateway'].rsplit('-', 1)[0].strip()
 
         return simple
+
+    def build_request(self) -> dict:
+        request = self._base_build_request()
+        entry = request[self.API_KEY_PATH.rsplit('.', 1)[1]]
+        entry[self.API_FIELD_DISABLED] = to_digit(
+            not is_true(entry[self.API_FIELD_ENABLED])
+        )
+        return request


### PR DESCRIPTION
## Summary

`oxlorg.opnsense.route` currently fails on the **second** run against any
OPNsense older than 26.1.10. Creating a route works; reading the route back
aborts the module.

OPNsense 26.1.10 renamed the static-route model's inverted `disabled` boolean to
a plain `enabled` one — [opnsense/core#10027](https://github.com/opnsense/core/pull/10027),
merged 2026-04-13, which bumped the `Routes` model from `1.0.0` to `1.0.1` and
shipped `M1_0_1.php` to migrate existing entries. Verified against the release
tags:

| tag | `src/opnsense/mvc/app/models/OPNsense/Routes/Route.xml` |
|---|---|
| `26.1.6` | `<version>1.0.0</version>`, field `<disabled type="BooleanField">` (default `0`) |
| `26.1.9` | `<version>1.0.0</version>`, field `<disabled type="BooleanField">` (default `0`) |
| `26.1.10` | `<version>1.0.1</version>`, field `<enabled type="BooleanField">` (default `1`) |

"fix: route enable-switch (#412)" answered that rename by dropping the
`enabled` → `disabled` translation and the `FIELDS_BOOL_INVERT` entry, while
leaving `'bool': ['enabled']` in `FIELDS_TYPING`. That is correct on 26.1.10 and
later. On everything before it the API still returns `disabled` and no
`enabled`, so `simplify_translate()` walks `FIELDS_TYPING`, misses the key, and
the module aborts:

```
THIS MIGHT BE A MODULE-BUG: Failed to translate API entry to Ansible entry!
Maybe the API changed lately? Failed field: 'enabled'
```

Reproduced on `latest` (`4f4acaf`) against a live **OPNsense 26.1.6_2**, running
`tests/route.yml` with the appliance's own gateway substituted for `LAN_GW` /
`TEST-GW`. It aborts on the first task that has to read an existing route back:

```
TASK [Adding 1] ****************************************************************
changed: [localhost]

TASK [Adding 2] ****************************************************************
fatal: [localhost]: FAILED! => THIS MIGHT BE A MODULE-BUG: Failed to translate
API entry to Ansible entry! Maybe the API changed lately? Failed field:
'enabled' | API entry: '{'network': '4.4.4.1/32', 'gateway': {...},
'descr': 'ANSIBLE_TEST_1', 'disabled': '0',
'uuid': '571d7ceb-d07c-4a0a-9c13-9a304f0c5b02'}'
```

Note `'disabled': '0'` in the entry the appliance returned, and no `enabled`
key at all. The same playbook on this branch, same appliance, runs clean:

```
TASK [Adding 2 - nothing changed] **********************************************
ok: [localhost]
TASK [Adding 2 - nothing changed with match-fields network & gateway] **********
ok: [localhost]
TASK [Disabling 1] *************************************************************
changed: [localhost]
TASK [Disabling 1 - nothing changed] *******************************************
ok: [localhost]
TASK [Enabling 1] **************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost : ok=12  changed=5  unreachable=0  failed=0
```

## Fix

Neither serialisation can be hardcoded, because both are in the field — and
OPNsense's own PR notes the change is breaking for downstream tooling that has
to span releases. So the module reads whichever the appliance has, rather than
picking a side:

* **reading** — whichever key the API returned is normalised to the module's
  `enabled` semantics, inverting only for `disabled`.
* **writing** — both keys are sent. `BaseField::setNodes()` iterates its *own*
  model items and picks the matching keys out of the payload, so the key the
  running model does not define is ignored rather than rejected.

One file, `plugins/module_utils/main/route.py`. No behaviour change on 26.1.10+.

## Result

`oxlorg.opnsense.route` is idempotent on 26.1.6 through 26.1.9 again, and
unchanged on 26.1.10 and later.


## Testing

Base: upstream `latest` at `4f4acaf`. Everything below is a run of this
branch's code as it stands on that base, against a live appliance — no probe
stands in for an appliance anywhere in this PR.

**Both sides of the version split were exercised on a real appliance.** One VM
was installed at 26.1.6 and then upgraded in place with `opnsense-update -bkp`,
so the same box was measured before and after the model rename:

| appliance | `Routes` model | `searchroute` returns | `latest` (`4f4acaf`) | this branch |
|---|---|---|---|---|
| OPNsense **26.1.6_2** | `1.0.0` | `"disabled": "0"` | **fails** — `Failed field: 'enabled'` | **passes** |
| OPNsense **26.1.11_10** | `1.0.1` | `"enabled": "1"` | passes | **passes** |

That the 26.1.11 appliance really is the post-rename case was confirmed against
the API rather than assumed — `POST routes/routes/addroute` followed by
`GET routes/routes/searchroute` returns `"enabled": "1"` with no `disabled` key,
where the 26.1.6 appliance returned `"disabled": "0"` with no `enabled` key.

What was run, on each appliance, in both normal and `--check` mode:

- `tests/route.yml`, with `LAN_GW`/`TEST-GW` replaced by the gateway the test
  appliance actually has. Structure and assertions are upstream's: create ×2,
  re-apply unchanged, re-apply unchanged with `match_fields: ['network',
  'gateway']`, disable, disable-unchanged, enable, `oxlorg.opnsense.list`
  read-back, delete both, list empty.
- The `list` read-back returns `enabled: true` as a real boolean on both
  releases.

Unit tests and lint, per upstream's own scripts:

- `scripts/unit_test.sh` — **486 passed**, identical to `latest`.
- `scripts/lint.sh` (pylint half) — **10.00/10**, with the same two pre-existing
  `missing-final-newline` findings `latest` has, in `haproxy_general_logging.py`
  and `haproxy_general_defaults.py`. Neither file is touched by this branch.

**Not verified:** 26.1.7, 26.1.8 and 26.1.9 specifically. The claim for those
releases rests on their `Route.xml` still carrying `<version>1.0.0</version>`
and the `disabled` field, which is the same serialisation 26.1.6 was measured
on, not on a run against each one.
