### PR TITLE
fix: fail on a delete OPNsense refused instead of reporting it as changed

### DIFF
--- a/plugins/module_utils/base/logic.py
+++ b/plugins/module_utils/base/logic.py
@@ -418,9 +418,88 @@ class BaseLogic:
             if self.p['debug']:
                 self.m.warn(f"{self.r['diff']}")
 
+            if isinstance(response, dict) and response.get('in_use', False):
+                self._base_delete_refused(response)
+
             return response
 
         return {}
+
+    def _base_delete_refused(self, response: dict) -> None:
+        # OPNsense refused the deletion because the item is still referenced
+        # somewhere in config.xml. Controllers that set
+        # $internalModelUseSafeDelete run checkAndThrowSafeDelete over the whole
+        # configuration, and a handful of others (firewall alias/group/category,
+        # routing gateways, interface vip/lagg/gre/gif/bridge) carry their own
+        # check. All of them answer with HTTP 500 and a message containing
+        # ' in use', which check_response() turns into this flag rather than
+        # failing on the spot - only the caller knows what was being deleted.
+        #
+        # Nothing was deleted, so the change has to be taken back. Reporting
+        # 'changed' here makes every following run report it again while the
+        # item stays exactly where it was.
+        self.r['changed'] = False
+        self.r['diff']['after'] = self.r['diff'].get('before', {})
+
+        detail = response.get('errorMessage', '')
+
+        if is_unset(detail):
+            detail = 'no detail returned by the API'
+
+        else:
+            # the API renders the referring items as an HTML list
+            detail = str(detail).replace('<br/>', '; ').replace('\n', '; ').strip('; ')
+
+        self._error_delete_refused(
+            f"Unable to delete {self.__class__.__name__} '{self._base_entry_id()}' - "
+            f"OPNsense refused it because the item is still referenced: {detail}"
+        )
+
+    def _base_entry_id(self) -> str:
+        # Whatever identifies the entry to the user who wrote the task, in
+        # descending order of how specific it is. Modules differ: some declare
+        # a single FIELD_ID, some let the caller choose match_fields, some
+        # carry a class-level FIELDS_MATCH and nothing else. Falling straight
+        # through to field_pk - 'uuid', which a delete-by-name task never sets -
+        # renders 'unknown' and leaves the failure naming no item at all.
+        fields = []
+
+        if hasattr(self, 'FIELD_ID'):
+            fields = [getattr(self, 'FIELD_ID')]
+
+        elif self.p.get('match_fields', None) is not None:
+            fields = self.p['match_fields']
+
+        elif hasattr(self, 'FIELDS_MATCH'):
+            fields = getattr(self, 'FIELDS_MATCH')
+
+        values = [
+            f"{f}={self.p[f]}" for f in fields
+            if f in self.p and not is_unset(self.p[f])
+        ]
+
+        if len(values) == 0:
+            # last resort before the uuid: the fields almost every model names
+            # its entries by
+            for field in ['name', 'description', 'descr']:
+                if field in self.p and not is_unset(self.p[field]):
+                    return f"{field}={self.p[field]}"
+
+            return str(self.p.get(self.field_pk, 'unknown'))
+
+        return ', '.join(values)
+
+    def _error_delete_refused(self, msg: str) -> None:
+        # A MultiModule passes explicit fail-behaviour; when it asked not to fail
+        # on processing errors (multi_control.fail_process, which purge_all
+        # implies) the entry is skipped with a warning so the remaining entries
+        # are still processed. Everywhere else this is a hard failure: the
+        # desired state was not reached and nothing else will say so.
+        if getattr(self, 'fail_explicit', False) and not getattr(self, 'fail_process', True):
+            self.m.warn(msg)
+            raise ModuleSoftError(msg)
+
+        self.m.fail_json(msg)
 
     def _base_reload(self) -> dict:
         # reload the running config

--- a/plugins/module_utils/base/module.py
+++ b/plugins/module_utils/base/module.py
@@ -14,6 +14,9 @@ class BaseModule(BaseLogic):
             # override params by MultiModule
             self.p = multi
 
+        # only a MultiModule passes fail-behaviour explicitly - a single module
+        # run has nothing to keep going for, so it must not soft-error
+        self.fail_explicit = len(f) > 0
         self.fail_verify = f.get('verify', False)
         self.fail_process = f.get('process', False)
 

--- a/plugins/module_utils/helper/api.py
+++ b/plugins/module_utils/helper/api.py
@@ -178,18 +178,25 @@ def check_response(module: AnsibleModule, cnf: dict, response) -> dict:
                 f"Response: {response.__dict__}"
             )
 
+        elif 'validations' in json:
+            # checked before the ' in use' case below: a validation error is a
+            # real failure even when one of its messages happens to contain
+            # 'in use' (OPNsense uses that wording for port and id clashes on
+            # *set*), and it never carries an errorMessage for a caller to act on
+            module.fail_json(
+                f"API call failed | Error: {json['validations']} | "
+                f"Response: {response.__dict__}"
+            )
+
         elif f"{response.__dict__}".find(' in use') != -1:
+            # OPNsense refuses to delete an item that is still referenced. Flag
+            # it rather than failing here - the caller knows what it was trying
+            # to delete. BaseLogic._base_delete() picks this up and fails with
+            # the referring items named.
             json['in_use'] = True
 
         else:
-            if 'validations' in json:
-                module.fail_json(
-                    f"API call failed | Error: {json['validations']} | "
-                    f"Response: {response.__dict__}"
-                )
-
-            else:
-                module.fail_json(f"API call failed | Response: {response.__dict__}")
+            module.fail_json(f"API call failed | Response: {response.__dict__}")
 
     return json
 

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -121,14 +121,9 @@ class Alias(BaseModule):
                 verification=False,
             )
 
-    def delete(self) -> None:
-        response = self._base_delete()
-
-        if 'in_use' in response:
-            self._error(
-                msg=f"Unable to delete alias '{self.p[self.FIELD_ID]}' as it is currently referenced!",
-                verification=False,
-            )
+    # delete() is not overridden any more: BaseLogic._base_delete() handles a
+    # refused deletion for every module now, and names the referring items the
+    # API reported instead of only stating that there are some.
 
     def _error(self, msg: str, verification: bool = True) -> None:
         if (verification and self.fail_verify) or (not verification and self.fail_process):

--- a/plugins/modules/raw.py
+++ b/plugins/modules/raw.py
@@ -131,6 +131,22 @@ def run_module():
             result['changed'] = True
             result['response'] = single_post(**req, headers=p['headers'])
 
+            if isinstance(result['response'], dict) and result['response'].get('in_use', False):
+                # OPNsense refused the call because the item it names is still
+                # referenced (safe-delete). Nothing happened, so 'changed' would
+                # be a lie - and this module is the only thing in the chain that
+                # can say so.
+                result['changed'] = False
+                detail = result['response'].get('errorMessage', 'no detail returned by the API')
+                # same rendering as BaseLogic._base_delete_refused: OPNsense
+                # separates the referring items with '<br/>' in some
+                # controllers and with '\n' in others
+                detail = str(detail).replace('<br/>', '; ').replace('\n', '; ').strip('; ')
+                module.fail_json(
+                    msg=f"API call '{m}/{c}/{cmd}' was refused because the item is still "
+                        f"referenced: {detail}",
+                    **result,
+                )
 
     module.exit_json(**result)
 

--- a/tests/alias_purge.yml
+++ b/tests/alias_purge.yml
@@ -166,7 +166,8 @@
       register: opn11
       failed_when: >
         not opn11.failed or
-        'currently referenced' not in opn11.msg
+        'still referenced' not in opn11.msg or
+        'ANSIBLE_TEST_4_1' not in opn11.msg
 
     - name: Purge ALL (except referenced by other)
       oxlorg.opnsense.alias_multi:


### PR DESCRIPTION
## Summary

When OPNsense **refuses** a deletion because the item is still referenced, every
module except `alias` reports it as a successful change. Nothing is deleted, the
task says `changed`, and it says `changed` again on the next run, for ever.

Three things combine to produce that:

1. OPNsense refuses to delete an item something else in `config.xml` still
   points at. Controllers that set `$internalModelUseSafeDelete` run
   `checkAndThrowSafeDelete` over the whole configuration; a handful of others
   carry their own hand-rolled check — `Firewall/Alias`, `Firewall/Group`,
   `Firewall/Category`, `Routing/Settings::delGatewayAction`,
   `Interfaces/{Vip,Lagg,Gre,Gif,Bridge}` and `Trust/Cert`. All of them raise a
   `UserException`, which `src/opnsense/www/api.php` renders as HTTP 500 with an
   `errorMessage` naming the referring items.
2. `check_response()` turns such a response into `json['in_use'] = True` instead
   of failing. That is the right call — only the caller knows what it was trying
   to delete.
3. But exactly one module ever read that flag, `main/alias.py`, and
   `_base_delete()` sets `changed = True` **before** the call goes out.

Reproduced on `latest` (`4f4acaf`) against a live **OPNsense 26.1.6_2**. A
traffic-shaper pipe with a queue pointing at it — what the appliance answers,
and what the collection then reports:

```
---- OPNsense's own answer to the delete (HTTP 500):
{"errorMessage":"TrafficShaper - REFDEL_QUEUE {TrafficShaper.queues.queue.686d664b-...}\n",
 "errorTitle":"Item pipes.pipe {REFDEL_PIPE} in use by:"}

---- what upstream/latest reports for the same delete:
TASK [Delete the referenced pipe] **********************************************
changed: [localhost]
    "msg": "RESULT failed=False changed=True msg=(none)"

pipes after the delete attempt: 1
>>> the pipe SURVIVED - the 'changed=True' above is a false report
```

The same scenario on this branch:

```
TASK [Delete the referenced pipe] **********************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg":
  "Unable to delete Pipe 'description=REFDEL_PIPE' - OPNsense refused it because
   the item is still referenced: TrafficShaper - REFDEL_QUEUE
   {TrafficShaper.queues.queue.b34cd54b-...}"}
```

One detail worth keeping in mind for anyone touching `check_response()` later:
in the safe-delete path the `' in use'` substring is in **`errorTitle`**, not in
`errorMessage`. The match works only because it runs over the whole stringified
response. Narrowing it to `json['errorMessage']` would silently kill detection
for every `$internalModelUseSafeDelete` controller.

## Fix

`_base_delete()` now handles the flag for every module: it takes the change
back, restores the diff, and fails with the resource identified and the API's own
message — which names the referring items — rather than only stating that there
are some. `main/alias.py`'s override goes away with it: the generic path covers
it and says more.

A `MultiModule` that asked not to fail on processing errors
(`multi_control.fail_process`, which `purge_all` implies) still gets a warning
and a soft error, so the remaining entries are processed. Everywhere else it is
a hard failure, because the desired state was not reached and nothing else will
say so. A single-module run previously raised `ModuleSoftError` with nothing to
catch it, which surfaced as a traceback rather than a message; `fail_explicit` on
`BaseModule` distinguishes the two cases.

`modules/raw.py` gets the same treatment — it is a thin passthrough that sets
`changed = True` before the POST, so a refused call through it reported a change
as well.

`_base_entry_id()` decides what to call the entry in that message. It resolves
`FIELD_ID`, then the caller's `match_fields`, then the class's own
`FIELDS_MATCH`, then `name`/`description`/`descr`, before falling back to the
uuid. Without the `FIELDS_MATCH` step a module that declares neither a
`FIELD_ID` nor a `match_fields` default — `frr_bgp_prefix_list`, for one —
rendered `Unable to delete Prefix 'unknown'`, naming nothing at all.

### `'validations'` is now checked before `' in use'`, and that is not cosmetic

The `' in use'` test is a substring match over the whole response object, so
**any** validation failure whose text happens to contain those words was
classified as a refused delete and swallowed into the `in_use` flag. OPNsense
really does use that wording on *add*:

* `Interfaces/Vip.php` — `"VHID %s is already in use on interface %s. Pick a
  unique number on this interface."`
* `Dnsmasq/Dnsmasq.php` — `"CNAME '%s' is already in use by a host override."`

Verified on a live 26.1.6 appliance. Creating a second CARP VIP with a VHID
already taken on that interface:

```
---- OPNsense's answer:
{"result":"failed","validations":{"vip.vhid":
  "VHID 77 is already in use on interface lan. Pick a unique number on this interface."}}

---- upstream/latest:
    "msg": "second: failed=False changed=True msg=(none)"
    # and the VIP list still contains exactly one VIP - nothing was created

---- this branch:
fatal: [localhost]: FAILED! => {"changed": false, "msg":
  "API call failed | Error: {'vip.vhid': 'VHID 77 is already in use on interface lan.
   Pick a unique number on this interface.'} | ..."}
```

So this half is not only about deletes: on `latest` a rejected **create**
reports `changed: true` and creates nothing.

## Result

A deletion OPNsense refused now fails the task and names what is holding the
item, instead of silently reporting a change that never happened. A genuine
validation error is no longer misclassified as a reference conflict.


## Testing

Base: upstream `latest` at `4f4acaf`. Every result below comes from running this
branch's code as it stands on that base against a **live appliance**. Nothing
here is a probe or a hand-constructed response.

Two appliance versions were used: OPNsense **26.1.6_2**, and then the same VM
upgraded in place with `opnsense-update -bkp` to **26.1.11_10**. The
controller-family table below was measured on **26.1.6_2**; the traffic-shaper
case and the whole regression suite were re-run on **26.1.11_10** and behave
identically, including the bug still being present on `latest` there.

Each scenario was built on the appliance (create A, make B reference A), the
delete attempted, and the item then **re-read over the API to confirm it
survived** — so "refused" is established from the appliance's state, not only
from the message. Every scenario was run twice: once with `latest` and once
with this branch.

### Controller families covered live

| Family | Check | Scenario | `latest` | this branch |
|---|---|---|---|---|
| `TrafficShaper/Settings` | safe-delete | pipe ← queue | `changed: true`, pipe survives | fails, names `REFDEL_QUEUE` |
| `Dnsmasq/Settings` | safe-delete | dhcp tag ← dhcp option | `changed: true`, tag survives | fails, names `REFDEL_OPT` |
| `DHCRelay/Settings` | safe-delete | destination ← relay | `changed: true`, dest survives | fails, names the relay |
| `Firewall/Category` | safe-delete | category ← alias, driven through `oxlorg.opnsense.raw` | `changed: true`, category survives | fails, names the alias |
| `HAProxy/Settings` (`os-haproxy`) | safe-delete | server ← backend | `changed: true`, server survives | fails, names `REFDEL_HBE` |
| `Quagga/Bgp` (`os-frr`) | safe-delete | prefix list ← neighbor | `changed: true`, list survives | fails, names the neighbors |
| `Firewall/Alias` | hand-rolled | alias ← nested alias | already failed (the one module upstream handled) | still fails, and now **names the referring alias** |

`Firewall/Category` is the `raw.py` half: the collection has no category module,
so `raw` is the only way to reach it, which makes it the natural test for that
code path. Verbatim, on this branch:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg":
  "API call 'firewall/category/del_item' was refused because the item is still
   referenced: Alias - holds the category {Alias.aliases.alias.ac953b99-...}",
  "response": {"errorMessage": "...", "errorTitle": "Item categories.category
   {REFDELCAT} in use by:", "in_use": true}}
```

The `ModuleSoftError` branch is covered too, by upstream's own
`tests/alias_purge.yml`: the `purge_all` step emits

```
[WARNING]: Unable to delete Alias 'name=ANSIBLE_TEST_4_1' - OPNsense refused it
because the item is still referenced: Cannot delete alias. Currently in use by ;
[aliases.alias.02f83b49-...]
changed: [localhost]
```

and goes on to purge the rest, which is the intended behaviour.

### Families NOT covered live, and why

| Family | Why not |
|---|---|
| `Routing/Settings::delGatewayAction` | Blocked by an **unrelated** upstream bug: on both 26.1.6 and 26.1.11 the `gateway` module aborts reading existing gateways with `Failed field: 'latencylow'` (`searchGateway` returns no such key for a dynamic gateway). Nothing to do with this PR, but it meant the gateway scenario could not be driven through the module. Worth its own issue. |
| `Interfaces/Vip` | Attempted: VIP + `source_nat` rule targeting it. OPNsense **allowed** the delete, so no refusal was produced and there was nothing to measure. `Vip::whereUsed()` did not match the rule the `source_nat` module writes. |
| `Interfaces/{Lagg,Gre,Gif,Bridge}` | The refusal only fires when the device is assigned in `<interfaces>`. Interface assignment has no API and no collection module, so this is not reachable from Ansible alone. |
| `Trust/Cert` | Refuses, but the collection has no certificate module. Reachable only via `raw`, which is already covered by `Firewall/Category`. |
| `Nginx/Settings`, `Caddy/ReverseProxy`, `UDPBroadcastRelay` | Plugins installed on the test appliance, but the collection has no module for the *referring* object needed to build the pair. |
| `Quagga/Ospfsettings`, `Quagga/Ospf6settings` | Same controller family and same `delBase()` path as `Quagga/Bgp`, which is covered. Not separately exercised. |
| `Firewall/Group` | Not exercised. |

### Two refusal shapes this fix does *not* detect

Both fall through to the pre-existing generic `module.fail_json`, so they fail
hard rather than lying — not a regression, but the coverage is not blanket:

* `Interfaces/Api/VlanSettingsController` — *"This VLAN cannot be deleted because
  it is used in QinQ interfaces"* / *"…assigned as an interface"*. No `' in use'`
  substring and no `errorTitle`.
* The second `Interfaces/Api/VipSettingsController` check — *"Cannot delete CARP
  Virtual IP, IP Alias with VHID Group %s still exists"*, whose `errorTitle` is
  just `"Error"`.

### Regression suite

Upstream's functional tests most exposed to this change, run on both appliance
versions, on both collections:

```
PASSED: alias 1_multi alias_multi alias_purge rule_purge raw
        shaper_pipe shaper_queue shaper_rule
        dhcrelay_destination dhcrelay_relay
FAILED: rule rule_multi interface_vip
```

The three failures are **identical on `latest`** and are environmental, not
code: the test appliance has only `lan` and `wan`, so `rule` wants a gateway it
does not have (`rule.replyto`), and `rule_multi` / `interface_vip` want an
`opt1` interface (`Option [opt1] not in list`). Everything else passes on both.

One upstream test needed updating and is included in this branch:
`tests/alias_purge.yml` asserted the old alias-only wording
(`'currently referenced' not in opn11.msg`). That message is deliberately
replaced by the generic one, so the assertion now checks for `'still
referenced'` and that the entry is named. Without that change upstream's own
suite fails against this branch.

### Unit tests and lint

* `scripts/unit_test.sh` — **486 passed**, identical to `latest`.
* `scripts/lint.sh` (pylint half) — **10.00/10**, with the same two pre-existing
  `missing-final-newline` findings `latest` has, in `haproxy_general_logging.py`
  and `haproxy_general_defaults.py`. Neither file is touched here.
