### PR TITLE
Add support for the expire field on firewall aliases of type external

### DIFF
--- a/docs/source/modules/alias.rst
+++ b/docs/source/modules/alias.rst
@@ -50,6 +50,7 @@ Definition
     "updatefreq_days","float","false","7.0 if type=urltable","\-","Needed only for the alias-type 'urltable' or 'urljson'. Interval to update its content. Per example: 0.5 for every 12 hours"
     "interface","string","false","\-","int, if","Needed only for the alias-type 'dynipv6host'. Select the interface for the V6 dynamic IP"
     "path_expression","string","false","\-","pr, jq","Needed only for the alias-type 'urljson'. Simplified expression to select a field inside a container, a dot is used as field separator (e.g. container.fieldname). Expressions using the jq language are also supported."
+    "expire","integer","false","\-","\-","Expiration time in seconds for alias-type 'external'. Minimum 60, maximum 999999999."
     "reload","boolean","false","false","\-", .. include:: ../_include/param_reload.rst
 
 .. include:: ../_include/param_basic.rst
@@ -159,6 +160,12 @@ Examples
             name: 'ANSIBLE_TEST_1_2_GEOIP2'
             type: 'geoip'
             content: ['AT', 'DE', 'CH']
+
+        - name: External alias with expiration
+          oxlorg.opnsense.alias:
+            name: 'external_dns_entries'
+            type: 'external'
+            expire: 86400
 
         - name: Reloading running config
           oxlorg.opnsense.reload:

--- a/plugins/module_utils/defaults/alias.py
+++ b/plugins/module_utils/defaults/alias.py
@@ -27,6 +27,12 @@ ALIAS_MOD_ARGS = dict(
         description='Simplified expression to select a field inside a container, a dot is used as field separator. '
                     'Expressions using the jq language are also supported.',
     ),
+    expire=dict(
+    type='int',
+    required=False,
+    default=None,
+    description="Expiration time in seconds for alias-type 'external'",
+    ),
     statistics=dict(
         type='bool', default=False, required=False,
     ),

--- a/plugins/module_utils/main/alias.py
+++ b/plugins/module_utils/main/alias.py
@@ -29,7 +29,7 @@ class Alias(BaseModule):
     FIELDS_ALL = ['name', 'type', 'enabled']
     FIELDS_ALL.extend(FIELDS_CHANGE)
     FIELDS_ALL.extend([
-        'updatefreq_days', 'interface', 'path_expression',
+        'updatefreq_days', 'interface', 'path_expression', 'expire',
         'url_auth_type', 'url_username', 'url_password',
     ])
     FIELDS_DIFF_NO_LOG = ['url_password']
@@ -43,6 +43,12 @@ class Alias(BaseModule):
     FIELDS_TYPING = {
         'bool': ['enabled', 'statistics'],
         'select': ['type', 'interface'],
+    }
+    INT_VALIDATIONS = {
+        'expire': {
+            'min': 60,
+            'max': 999999999,
+        },
     }
     EXIST_ATTR = 'alias'
     JOIN_CHAR = '\n'
@@ -70,6 +76,9 @@ class Alias(BaseModule):
                 self.m.fail_json('You need to provide an interface to create a dynipv6host alias!')
 
             self.FIELDS_CHANGE = self.FIELDS_CHANGE + ['interface']
+            
+        elif self.p['type'] == 'external':
+            self.FIELDS_CHANGE = self.FIELDS_CHANGE + ['expire']
 
         if len(self.p['name']) > self.MAX_ALIAS_LEN:
             self._error(

--- a/tests/alias.yml
+++ b/tests/alias.yml
@@ -514,6 +514,7 @@
         - 'ANSIBLE_TEST_1_2_GEOIP2'
         - 'ANSIBLE_TEST_1_2_GEOIP3'
         - 'ANSIBLE_TEST_1_2_DYNIPV6HOST1'
+        - 'ANSIBLE_TEST_1_2_EXTERNAL1'
 
 - name: Testing Alias - listing
   hosts: localhost

--- a/tests/alias.yml
+++ b/tests/alias.yml
@@ -442,6 +442,39 @@
           - '::1000'
           - '::f00d'
         interface: 'lan'
+    
+    # external
+    - name: Adding external alias with expiration
+      oxlorg.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_EXTERNAL1'
+        type: 'external'
+        expire: 60
+      register: opn_external1
+      failed_when: >
+        opn_external1.failed or
+        not opn_external1.changed
+    
+    - name: Adding external alias with expiration - nothing changed
+      oxlorg.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_EXTERNAL1'
+        type: 'external'
+        expire: 60
+      register: opn_external2
+      failed_when: >
+        opn_external2.failed or
+        opn_external2.changed
+      when: not ansible_check_mode
+    
+    - name: Updating external alias expiration
+      oxlorg.opnsense.alias:
+        name: 'ANSIBLE_TEST_1_2_EXTERNAL1'
+        type: 'external'
+        expire: 120
+      register: opn_external3
+      failed_when: >
+        opn_external3.failed or
+        not opn_external3.changed
+      when: not ansible_check_mode
 
     # cleanup
 


### PR DESCRIPTION
OPNsense supports an expiration value for external aliases, but the Ansible module currently does not expose or track this field.

Changes

- Add expire as an optional integer parameter for aliases
- Include expire in the API payload
- Track expire as a changeable field for aliases of type external
- Validate the supported OPNsense range:
  - Minimum: 60
  - Maximum: 999999999
- Add/update tests for:
  - Creating an external alias with an expiration value
  - Idempotency
  - Updating the expiration value
- Update module documentation